### PR TITLE
Simplify Dockerfile: install taskgen from GitHub

### DIFF
--- a/action/Dockerfile
+++ b/action/Dockerfile
@@ -35,18 +35,15 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
 # Install Claude Code CLI
 RUN npm install -g @anthropic-ai/claude-code
 
-WORKDIR /taskgen
-
-# Copy taskgen source and install
-COPY pyproject.toml uv.lock README.md ./
-COPY src/ ./src/
-
-# Install taskgen with all dependencies
-RUN uv sync --frozen
+# Install taskgen from GitHub (uses the same ref as the action)
+ARG TASKGEN_REF=main
+RUN uv pip install --system "git+https://github.com/abundant-ai/taskgen.git@${TASKGEN_REF}"
 
 # Copy action entrypoint
 COPY action/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+
+WORKDIR /workspace
 
 # Set up environment
 ENV PYTHONUNBUFFERED=1

--- a/action/README.md
+++ b/action/README.md
@@ -26,7 +26,7 @@ jobs:
         with:
           fetch-depth: 0
       
-      - uses: abundant-ai/taskgen@v1
+      - uses: abundant-ai/taskgen/action@main
         id: harbor-check
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -104,10 +104,7 @@ TASK_ID=$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')
 echo "::group::Building taskgen command"
 echo "Task ID: $TASK_ID"
 
-# Run taskgen from its installation directory
-cd /taskgen
-
-CMD="uv run taskgen create"
+CMD="taskgen create"
 CMD+=" --repo $REPO"
 CMD+=" --pr $PR_NUMBER"
 CMD+=" --output $TASK_OUTPUT"

--- a/action/workflow-template.yml
+++ b/action/workflow-template.yml
@@ -38,7 +38,7 @@ jobs:
       
       - name: Check Harbor Task Eligibility
         id: harbor-check
-        uses: abundant-ai/taskgen@v1
+        uses: abundant-ai/taskgen/action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           


### PR DESCRIPTION
Instead of copying source files and building locally, install taskgen directly from GitHub. This is cleaner and standard practice for actions.

Benefits:
- No need to track uv.lock in git
- No need to copy pyproject.toml, src/, README.md
- Simpler build process
- Always installs the correct version matching the action ref

Changes:
- Use 'uv pip install git+https://...' instead of local install
- Remove COPY commands for source files
- Update entrypoint.sh to use 'taskgen' directly (installed system-wide)
- Update documentation to use 'taskgen/action@main' path