### PR TITLE
Fix Dockerfile path for subdirectory action

### DIFF
--- a/action/Dockerfile
+++ b/action/Dockerfile
@@ -39,8 +39,8 @@ RUN npm install -g @anthropic-ai/claude-code
 ARG TASKGEN_REF=main
 RUN uv pip install --system "git+https://github.com/abundant-ai/taskgen.git@${TASKGEN_REF}"
 
-# Copy action entrypoint
-COPY action/entrypoint.sh /entrypoint.sh
+# Copy action entrypoint (from action/ subdirectory context)
+COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 WORKDIR /workspace


### PR DESCRIPTION
When using `abundant-ai/taskgen/action@main`, GitHub Actions sets the Docker build context to the action/ directory.

This means `COPY action/entrypoint.sh` fails because it looks for `action/action/entrypoint.sh`.

Fix: Change to `COPY entrypoint.sh` since we're already in the action/ directory.