### PR TITLE
CC prompt: pin language deps via lockfiles, never pin apt versions

### DIFF
--- a/src/swegen/create/claude_code_runner.py
+++ b/src/swegen/create/claude_code_runner.py
@@ -99,6 +99,12 @@ Look for what the reference added beyond the basic skeleton:
 - Build steps
 - Post-patch rebuild steps
 
+**Dependency pinning:** pin language deps via lock files (`npm ci`,
+`--frozen-lockfile`, uv/pip with the lock, `cargo fetch`, `go mod download`,
+`bundle install`), but do NOT pin apt/system package versions
+(`apt-get install -y pkg`, never `pkg=1.2.3`) — Ubuntu/Debian purge old versions,
+so pinned apt installs break future rebuilds and a CI check rejects them.
+
 ### Step 2: Fill In Your Skeleton's TODOs
 
 **CRITICAL: Always use Ubuntu base image**
@@ -536,6 +542,20 @@ RUN apt-get update && apt-get install -y openjdk-17-jdk maven && \\
 - **Rust:** `cargo fetch`
 - **Ruby:** `bundle install`
 - **Java:** `mvn dependency:resolve`
+
+**Dependency Pinning Policy (reproducibility WITHOUT breaking future builds):**
+
+- **DO pin language/package-manager dependencies via lock files.** Their registries
+  (PyPI, npm, crates.io, RubyGems, Maven Central, Go module proxy) keep old versions
+  indefinitely, so pinned installs stay reproducible AND keep building over time:
+  `npm ci`, `yarn/pnpm install --frozen-lockfile`, uv/pip against the lock or a pinned
+  `requirements.txt`, `cargo fetch` (Cargo.lock), `go mod download` (go.sum),
+  `bundle install` (Gemfile.lock).
+- **Do NOT pin apt / system package versions** (e.g. `apt-get install -y libfoo=1.2.3`).
+  Ubuntu/Debian keep only the current version of each package in a release pocket and
+  purge older ones, so a pinned `apt` version stops resolving after the next archive
+  update and the task can no longer build. Install apt packages UNPINNED:
+  `apt-get install -y libfoo`. (A CI check rejects Dockerfiles that pin apt versions.)
 
 **Build Steps (for compiled languages):**
 


### PR DESCRIPTION
Teaches Claude Code the dependency-pinning policy so generated Dockerfiles are reproducible without rotting: pin language/package-manager deps via lock files (`npm ci`, `--frozen-lockfile`, uv/pip+lock, `cargo fetch`, `go mod download`, `bundle install`) whose registries retain old versions, but do NOT pin apt/system package versions (`apt-get install pkg=1.2.3`) — Ubuntu/Debian purge old versions from the archive, so pinned apt installs break future rebuilds.

_Part of a series of task-authoring conditions. Independent; smallest diff._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only changes to `claude_code_runner.py`; no runtime or CI logic modified in this diff.
> 
> **Overview**
> Extends the **Claude Code** Harbor task prompts in `claude_code_runner.py` so generated Dockerfiles follow a clear **dependency pinning** rule.
> 
> In the **reference-task** flow, a short note is added when comparing Dockerfiles: use lockfile-based installs for language deps, and never version-pin `apt` packages.
> 
> In the **from-scratch** `CC_PROMPT`, a **Dependency Pinning Policy** block is added after the existing dependency-install examples. It tells the agent to pin via lock files (`npm ci`, frozen yarn/pnpm, uv/pip + lock, `cargo fetch`, `go mod download`, `bundle install`) and to install system packages with unpinned `apt-get install`, because Debian/Ubuntu archives drop old versions and CI rejects pinned apt lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7714dfbce4612d3c35f9357b8d92673136e904b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->