### PR TITLE
Enforce offline tests: no dependency installs / network in test.sh

### DIFF
--- a/src/swegen/analyze/run.py
+++ b/src/swegen/analyze/run.py
@@ -31,6 +31,7 @@ from swegen.tools.harbor_runner import (
     parse_harbor_outcome,
     run_harbor_agent,
 )
+from swegen.tools.policy import find_test_network_violations
 
 
 def _setup_claude_auth_preference(console: Console) -> None:
@@ -129,6 +130,7 @@ class AnalyzeArgs:
     timeout_multiplier: float = 1.0
     classification_timeout: int = 300  # Timeout per classification in seconds (5 min default)
     verdict_timeout: int = 180  # Timeout for verdict synthesis in seconds (3 min default)
+    enforce_offline_tests: bool = True  # Flag test.sh installs/network in the quality check
 
 
 def run_analyze(args: AnalyzeArgs) -> AnalysisResult:
@@ -182,7 +184,9 @@ def _run_analysis(
     quality_check = None
     if not args.skip_quality_check:
         console.print("\n[bold blue]Step 1/4: Static Quality Check[/bold blue]")
-        quality_check = _run_quality_check(task_path, args.analysis_model, console)
+        quality_check = _run_quality_check(
+            task_path, args.analysis_model, console, args.enforce_offline_tests
+        )
     else:
         console.print("\n[dim]Step 1/4: Static Quality Check (skipped)[/dim]")
 
@@ -275,6 +279,7 @@ def _run_quality_check(
     task_path: Path,
     model: str,
     console: Console,
+    enforce_offline_tests: bool = True,
 ) -> QualityCheckResult:
     """Run Harbor's static quality check on the task."""
     cmd = harbor_cmd_base() + [
@@ -304,6 +309,12 @@ def _run_quality_check(
                     parts = [p.strip() for p in clean_line.split("│")]
                     if len(parts) >= 2 and any(k in parts[1].lower() for k in ["fail"]):
                         issues.append(parts[0])
+
+    # Offline-tests policy: tests/test.sh must not install deps or access the network.
+    # Respect the same opt-out as create/validate/farm (--allow-test-network).
+    if enforce_offline_tests:
+        for v in find_test_network_violations(task_path):
+            issues.append(f"offline-tests: test.sh {v.label} (line {v.line_number})")
 
     passed = proc.returncode == 0 and len(issues) == 0
 

--- a/src/swegen/cli.py
+++ b/src/swegen/cli.py
@@ -92,6 +92,13 @@ def create_cmd(
         False,
         help="Allow processing unmerged PRs (for testing/preview); --allow-unmerged to enable",
     ),
+    enforce_offline_tests: bool = typer.Option(
+        True,
+        "--offline-tests/--allow-test-network",
+        help="Forbid dependency installs / network access in tests/test.sh and set "
+        "[environment].allow_internet=false in task.toml (internet only during Docker build); "
+        "--allow-test-network to disable",
+    ),
     environment: str = typer.Option(
         "docker",
         "-e",
@@ -118,6 +125,7 @@ def create_cmd(
         allow_unmerged=allow_unmerged,
         environment=EnvironmentType(environment),
         generate_name=generate_name,
+        enforce_offline_tests=enforce_offline_tests,
         verbose=verbose,
         quiet=quiet,
     )
@@ -174,6 +182,12 @@ def validate(
         help="Run docker cleanup after every N tasks (0 to disable, local docker only)",
         show_default=True,
     ),
+    enforce_offline_tests: bool = typer.Option(
+        True,
+        "--offline-tests/--allow-test-network",
+        help="Fail tasks whose tests/test.sh installs deps or accesses the network at "
+        "test time (offline-tests policy); --allow-test-network to disable",
+    ),
 ) -> None:
     if agent not in ("both", "nop", "oracle"):
         raise typer.BadParameter("agent must be one of: both, nop, oracle")
@@ -191,6 +205,7 @@ def validate(
             show_passed=show_passed,
             output_file=output,
             docker_prune_batch=docker_prune_batch,
+            enforce_offline_tests=enforce_offline_tests,
         )
     )
 
@@ -264,6 +279,12 @@ def analyze(
         help="OpenAI model for verdict synthesis",
         show_default=True,
     ),
+    enforce_offline_tests: bool = typer.Option(
+        True,
+        "--offline-tests/--allow-test-network",
+        help="Flag tests/test.sh installs or network access in the quality check; "
+        "--allow-test-network to disable",
+    ),
 ) -> None:
     """
     Analyze a Harbor task to determine if it's well-specified.
@@ -312,6 +333,7 @@ def analyze(
             verbose=verbose,
             classification_timeout=classification_timeout,
             verdict_timeout=verdict_timeout,
+            enforce_offline_tests=enforce_offline_tests,
         )
     )
 
@@ -381,6 +403,13 @@ def farm(
     validate: bool = typer.Option(
         True, help="Run Harbor validation after CC; --no-validate to skip"
     ),
+    enforce_offline_tests: bool = typer.Option(
+        True,
+        "--offline-tests/--allow-test-network",
+        help="Forbid dependency installs / network access in tests/test.sh and set "
+        "[environment].allow_internet=false in task.toml (internet only during Docker build); "
+        "--allow-test-network to disable",
+    ),
 ) -> None:
     """
     Continuously process merged GitHub PRs and convert them to Harbor tasks.
@@ -409,6 +438,7 @@ def farm(
         verbose=verbose,
         require_issue=require_issue,
         validate=validate,
+        enforce_offline_tests=enforce_offline_tests,
     )
 
     console = Console()

--- a/src/swegen/config.py
+++ b/src/swegen/config.py
@@ -31,6 +31,10 @@ class CreateConfig:
         allow_unmerged: Allow processing unmerged PRs (for testing/preview, default: False)
         environment: Environment type for Harbor runs (docker, daytona, e2b, modal, runloop, gke)
         generate_name: Generate semantic task name instead of PR number
+        enforce_offline_tests: Forbid runtime dependency installs / network access in tests/test.sh.
+            When True (default): CC is told not to install/network in test.sh, a static gate hard-fails
+            any test.sh that does, and the generated task.toml sets [environment].allow_internet=false
+            (internet is available only during the Docker build). Disable with --allow-test-network.
         verbose: Increase output verbosity
         quiet: Reduce output verbosity
     """
@@ -50,6 +54,7 @@ class CreateConfig:
     allow_unmerged: bool = False
     environment: EnvironmentType = EnvironmentType.DOCKER
     generate_name: bool = False
+    enforce_offline_tests: bool = True
     verbose: bool = False
     quiet: bool = False
 
@@ -90,6 +95,8 @@ class FarmConfig:
         verbose: Enable verbose output
         require_issue: Require PR to have a linked issue (higher quality instructions)
         validate: Run Harbor validation after CC (useful when CC times out but task may be valid)
+        enforce_offline_tests: Forbid runtime dependency installs / network access in tests/test.sh
+            (see CreateConfig). Disable with --allow-test-network.
     """
 
     repo: str
@@ -113,6 +120,7 @@ class FarmConfig:
     verbose: bool = False
     require_issue: bool = True
     validate: bool = True
+    enforce_offline_tests: bool = True
 
 
 @dataclass(frozen=True)

--- a/src/swegen/create/claude_code_runner.py
+++ b/src/swegen/create/claude_code_runner.py
@@ -29,6 +29,34 @@ class ClaudeCodeResult:
     cc_output: str | None = None
 
 
+# Appended to the CC prompt when offline-tests enforcement is on. The generated
+# task.toml sets allow_internet=false, so the verifier container has no network;
+# a static gate also hard-fails any test.sh that installs/fetches at test time.
+TEST_OFFLINE_CONSTRAINT = """
+## HARD CONSTRAINT: tests/test.sh must be fully offline
+
+The verifier runs with **no network access** (task.toml sets `allow_internet = false`).
+Internet is available **only during the Docker image build** (the Dockerfile).
+
+Therefore:
+- **All** language runtimes, system packages, project dependencies, and build steps
+  MUST be installed/performed in the **Dockerfile** (build time).
+- `tests/test.sh` MUST NOT install anything or touch the network. Do NOT put any of
+  these in test.sh: `pip/uv/poetry/pipenv install`, `npm/yarn/pnpm/bun install`,
+  `apt-get/apk/yum install`, `go get`/`go mod download`, `cargo fetch/install`,
+  `gem install`, `bundle install`, `corepack prepare`, `curl`/`wget`, or
+  `git clone/fetch/pull`.
+- test.sh should only: set env vars, copy the held-out test files, and run the test
+  command (e.g. `pytest ...`, `go test ...`, `cargo test ...`, `bundle exec rspec ...`,
+  `npx jest ... --coverage=false`). These runners are fine — installers are not.
+- If a test needs a dependency, add it to the **Dockerfile**, not test.sh. If the
+  install/build is only needed after applying bug.patch, do the rebuild in the
+  Dockerfile after the `patch -p1 < bug.patch` step.
+
+A task that installs or fetches over the network in test.sh will be **rejected**.
+"""
+
+
 # The prompt for CC when using a reference task (much simpler task)
 CC_REFERENCE_PROMPT = """
 ## Your Task: Fill In Skeleton Using Reference Task as Example
@@ -720,6 +748,7 @@ def run_claude_code_session(
     reference_pr: int | None = None,
     head_sha: str | None = None,
     environment: str = "docker",
+    enforce_offline_tests: bool = True,
 ) -> ClaudeCodeResult:
     """
     Run Claude Code session to complete skeleton and make harbor pass.
@@ -758,6 +787,7 @@ def run_claude_code_session(
             reference_pr=reference_pr,
             head_sha=head_sha,
             environment=environment,
+            enforce_offline_tests=enforce_offline_tests,
         )
     )
 
@@ -776,6 +806,7 @@ async def _run_claude_code_session_async(
     reference_pr: int | None = None,
     head_sha: str | None = None,
     environment: str = "docker",
+    enforce_offline_tests: bool = True,
 ) -> ClaudeCodeResult:
     """Async implementation of Claude Code session."""
     logger = logging.getLogger("swegen")
@@ -831,6 +862,11 @@ async def _run_claude_code_session_async(
             environment=environment,
         )
         logger.info("Using full prompt (generating from skeleton)")
+
+    # Append the offline-tests hard constraint so CC never puts installs/network
+    # in test.sh (task.toml also enforces this at runtime via allow_internet=false).
+    if enforce_offline_tests:
+        prompt_text = prompt_text + "\n" + TEST_OFFLINE_CONSTRAINT
 
     # Create hook for logging Harbor validation attempts
     harbor_runs: list[str] = []

--- a/src/swegen/create/create.py
+++ b/src/swegen/create/create.py
@@ -18,6 +18,7 @@ from rich.traceback import install as rich_traceback_install
 
 from swegen.config import CreateConfig
 from swegen.tools.harbor_runner import parse_harbor_outcome, run_harbor_agent
+from swegen.tools.policy import find_test_network_violations, format_violations
 from swegen.tools.validate_utils import ValidationError, run_nop_oracle
 
 from . import MissingIssueError, PRToHarborPipeline, TrivialPRError
@@ -491,6 +492,7 @@ def run_reversal(config: CreateConfig) -> None:
                     max_source_files=config.max_source_files,
                     environment=config.environment.value,
                     generate_task_name=config.generate_name,
+                    enforce_offline_tests=config.enforce_offline_tests,
                 )
 
             skeleton_secs = time.perf_counter() - t0
@@ -534,6 +536,7 @@ def run_reversal(config: CreateConfig) -> None:
                 reference_pr=task_reference.pr_number if task_reference else None,
                 head_sha=metadata.get("head_sha"),
                 environment=config.environment.value,
+                enforce_offline_tests=config.enforce_offline_tests,
             )
 
             gen_secs = time.perf_counter() - t0
@@ -577,6 +580,27 @@ def run_reversal(config: CreateConfig) -> None:
 
         # Task ID from generated dir
         task_id = task_dir.name
+
+        # Offline-tests policy gate: tests/test.sh must not install deps or hit the network
+        # (deps belong in the Dockerfile; the verifier runs with no network). Run this BEFORE
+        # Harbor validation so we (a) fail fast without spinning up Docker, and (b) always report
+        # the violation even when NOP/Oracle or CC checks would otherwise fail first.
+        if config.enforce_offline_tests:
+            offline_violations = find_test_network_violations(task_dir)
+            if offline_violations:
+                console.print()
+                console.print(
+                    Panel(
+                        Text(format_violations(task_dir, offline_violations), style="red"),
+                        title="[red]Offline Tests Policy Violation[/red]",
+                        border_style="red",
+                    )
+                )
+                raise ValidationError(
+                    "tests/test.sh installs dependencies or accesses the network "
+                    "(offline-tests policy). Move all installs/builds into the Dockerfile."
+                )
+
         harbor_do = not config.no_validate
 
         # If CC already validated successfully, skip harbor validation

--- a/src/swegen/create/orchestrator.py
+++ b/src/swegen/create/orchestrator.py
@@ -107,6 +107,7 @@ class PRToHarborPipeline:
         max_source_files: int = 10,
         environment: str = "docker",
         generate_task_name: bool = False,
+        enforce_offline_tests: bool = True,
     ) -> tuple[Path, ClaudeCodeResult | None, list[str], TaskReference | None]:
         """
         Generate a Harbor task using skeleton + Claude Code.
@@ -342,7 +343,9 @@ class PRToHarborPipeline:
 
             # instruction.md and task.toml
             paths.instruction_path.write_text(generate_instruction_md(instruction_data))
-            paths.config_path.write_text(generate_task_toml(instruction_data))
+            paths.config_path.write_text(
+                generate_task_toml(instruction_data, enforce_offline_tests=enforce_offline_tests)
+            )
 
             # solution/fix.patch - the actual fix to apply
             (paths.solution_dir / "fix.patch").write_text(solution_diff)
@@ -380,6 +383,7 @@ class PRToHarborPipeline:
                     reference_pr=task_reference.pr_number if task_reference else None,
                     head_sha=metadata.get("head_sha"),
                     environment=environment,
+                    enforce_offline_tests=enforce_offline_tests,
                 )
 
                 if cc_result.success:

--- a/src/swegen/create/task_skeleton.py
+++ b/src/swegen/create/task_skeleton.py
@@ -162,6 +162,11 @@ def generate_test_sh(
 
 cd /app/src
 
+# OFFLINE TESTS POLICY: do NOT install dependencies or access the network here.
+# All runtime deps, tools, and build steps must be installed in the Dockerfile
+# (build time, where the internet is available). This container runs the tests
+# with no network access, so any live install here will fail.
+
 # TODO: Set environment variables if needed for tests
 # Examples: CI=true, NODE_ENV=test, RUST_BACKTRACE=1
 
@@ -178,9 +183,8 @@ cd /app/src
 # Examples for different languages/frameworks:
 #
 # Python (pytest with uv):
-#   # If using uv venv at /opt/venv:
+#   # If using uv venv at /opt/venv (deps already installed at build time):
 #   source /opt/venv/bin/activate
-#   uv pip install -e . --no-deps 2>/dev/null || true  # Reinstall to pick up changes
 #   pytest -xvs path/to/test_file.py
 #   # Or without venv activation:
 #   /opt/venv/bin/pytest -xvs path/to/test_file.py
@@ -243,11 +247,25 @@ def generate_instruction_md(instruction_data: dict) -> str:
     return instruction_data["instruction"]
 
 
-def generate_task_toml(instruction_data: dict) -> str:
+def generate_task_toml(instruction_data: dict, enforce_offline_tests: bool = True) -> str:
     """Generate task.toml config file for Harbor format.
 
     Uses Harbor's TaskConfig for proper serialization and validation.
+
+    When ``enforce_offline_tests`` is True, the environment is configured with
+    ``allow_internet=false`` so the agent/verifier container runs with no network.
+    Internet remains available during the Docker image build (build is not gated
+    by this flag), matching the "internet only during environment setup" policy.
     """
+    env_kwargs: dict = {
+        "build_timeout_sec": 600.0,
+        "cpus": 1,
+        "memory_mb": 2048,
+        "storage_mb": 10240,
+    }
+    if enforce_offline_tests:
+        env_kwargs["allow_internet"] = False
+
     config = TaskConfig(
         metadata={
             "difficulty": instruction_data.get("difficulty", "medium"),
@@ -256,11 +274,6 @@ def generate_task_toml(instruction_data: dict) -> str:
         },
         verifier=VerifierConfig(timeout_sec=600.0),
         agent=AgentConfig(timeout_sec=600.0),
-        environment=EnvironmentConfig(
-            build_timeout_sec=600.0,
-            cpus=1,
-            memory_mb=2048,
-            storage_mb=10240,
-        ),
+        environment=EnvironmentConfig(**env_kwargs),
     )
     return config.model_dump_toml()

--- a/src/swegen/farm/farm_hand.py
+++ b/src/swegen/farm/farm_hand.py
@@ -218,6 +218,7 @@ def _run_reversal_for_pr_impl(
         max_source_files=config.max_source_files,
         require_issue=config.require_issue,
         environment=config.environment,
+        enforce_offline_tests=config.enforce_offline_tests,
     )
 
     # Capture any errors from the pipeline

--- a/src/swegen/tools/policy.py
+++ b/src/swegen/tools/policy.py
@@ -155,14 +155,21 @@ def _main(argv: list[str]) -> int:
                 d for d in sorted(p.iterdir()) if (d / "tests" / "test.sh").exists()
             )
 
+    # No resolvable tasks almost always means a wrong/empty path argument; exit non-zero
+    # (distinct from the violation code) so pre-commit/CI don't treat it as a passing scan.
+    if not task_dirs:
+        print(
+            "policy: no tasks with tests/test.sh found in given paths (check the path)",
+            file=sys.stderr,
+        )
+        return 2
+
     had_violation = False
     for task_dir in task_dirs:
         violations = find_test_network_violations(task_dir)
         if violations:
             had_violation = True
             print(format_violations(task_dir, violations), file=sys.stderr)
-    if not task_dirs:
-        print("policy: no tasks with tests/test.sh found in given paths", file=sys.stderr)
     return 1 if had_violation else 0
 
 

--- a/src/swegen/tools/policy.py
+++ b/src/swegen/tools/policy.py
@@ -1,0 +1,170 @@
+"""Static task-policy checks.
+
+Currently enforces the *offline tests* policy:
+
+    tests/test.sh must NOT install dependencies or access the network.
+    All dependencies, tools, and builds belong in the Dockerfile, where the
+    internet is available at build time. The verifier/test container runs with
+    no network (task.toml sets [environment].allow_internet = false), so any
+    live install in test.sh would fail at runtime anyway. This check catches it
+    statically at generation/validation time with a clear message.
+
+The check is intentionally conservative to avoid false positives on legitimate
+test runners (``bundle exec rspec``, ``go test``, ``cargo test``, ``npx jest``,
+``mvn test`` …): it flags explicit installers and network-fetch commands only,
+and exempts lines that opt into a clearly-offline mode (``--no-index`` /
+``--offline``).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# Tokens that make an otherwise-flagged install run without network access.
+# If present on a line, the line is not considered a violation.
+_OFFLINE_MARKERS = ("--no-index", "--offline")
+
+# (compiled regex, human-readable label). Patterns match against a shell line
+# with inline comments stripped. Kept deliberately narrow: the *verb* must be an
+# install/fetch, so test *runners* (go test, cargo test, mvn test, npx <runner>,
+# bundle exec) are not matched.
+_VIOLATION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"\bapt(?:-get)?\s+(?:-\S+\s+)*install\b"), "apt install"),
+    (re.compile(r"\badd-apt-repository\b"), "add-apt-repository"),
+    (re.compile(r"\bapk\s+add\b"), "apk add"),
+    (re.compile(r"\byum\s+install\b"), "yum install"),
+    (re.compile(r"\bdnf\s+install\b"), "dnf install"),
+    (re.compile(r"\bpip[0-9.]*\s+install\b"), "pip install"),
+    (re.compile(r"\bpython[0-9.]*\s+-m\s+pip\s+install\b"), "python -m pip install"),
+    (re.compile(r"\bpip[0-9.]*\s+download\b"), "pip download"),
+    (re.compile(r"\buv\s+pip\s+install\b"), "uv pip install"),
+    (re.compile(r"\buv\s+(?:add|sync)\b"), "uv add/sync"),
+    (re.compile(r"\bpoetry\s+(?:add|install|lock)\b"), "poetry add/install"),
+    (re.compile(r"\bpipenv\s+(?:install|sync)\b"), "pipenv install"),
+    (re.compile(r"\b(?:conda|mamba)\s+install\b"), "conda install"),
+    (re.compile(r"\bnpm\s+(?:i|ci|install|add)\b"), "npm install"),
+    (re.compile(r"\byarn\s+(?:add|install)\b"), "yarn add/install"),
+    (re.compile(r"\bpnpm\s+(?:i|add|install)\b"), "pnpm install"),
+    (re.compile(r"\bbun\s+(?:add|install)\b"), "bun add/install"),
+    (re.compile(r"\bcorepack\s+prepare\b"), "corepack prepare (downloads)"),
+    (re.compile(r"\bgo\s+(?:get|install)\b"), "go get/install"),
+    (re.compile(r"\bgo\s+mod\s+download\b"), "go mod download"),
+    (re.compile(r"\bcargo\s+(?:fetch|install|add|update)\b"), "cargo fetch/install/add"),
+    (re.compile(r"\bgem\s+install\b"), "gem install"),
+    (re.compile(r"\bbundle\s+(?:install|update)\b"), "bundle install/update"),
+    (re.compile(r"\bmvn\b.*(?:dependency:|(?<!-)\binstall\b)"), "maven dependency resolution"),
+    (re.compile(r"\bgradle\b.*(?:--refresh-dependencies|\bdependencies\b)"), "gradle dependency resolution"),
+    (re.compile(r"\bcurl\b"), "curl (network fetch)"),
+    (re.compile(r"\bwget\b"), "wget (network fetch)"),
+    (re.compile(r"\bgit\s+(?:clone|fetch|pull)\b"), "git clone/fetch/pull"),
+]
+
+_COMMENT_RE = re.compile(r"(?<!\S)#.*$")
+
+
+@dataclass(frozen=True)
+class TestNetworkViolation:
+    """A single offending line in tests/test.sh."""
+
+    line_number: int
+    line: str
+    label: str
+
+    def __str__(self) -> str:
+        return f"  line {self.line_number}: {self.label}  ->  {self.line.strip()}"
+
+
+def _strip_comment(line: str) -> str:
+    """Remove an inline shell comment (a ``#`` at line start or after whitespace)."""
+    return _COMMENT_RE.sub("", line)
+
+
+# Shell command separators, used to break a line into individual commands so an
+# offline marker (e.g. --no-index) only exempts the command it belongs to.
+_SEGMENT_SPLIT = re.compile(r"&&|\|\||;|\|")
+
+
+def scan_test_script(script_text: str) -> list[TestNetworkViolation]:
+    """Scan the text of a test.sh for install/network commands.
+
+    Pure function over the script contents so it is easy to unit-test.
+    """
+    violations: list[TestNetworkViolation] = []
+    for i, raw in enumerate(script_text.splitlines(), start=1):
+        code = _strip_comment(raw)
+        if not code.strip():
+            continue
+        # Split into individual command segments so an offline marker only exempts the command
+        # it applies to — other install/network commands chained on the same line are still checked.
+        for segment in _SEGMENT_SPLIT.split(code):
+            seg = segment.strip()
+            if not seg:
+                continue
+            if any(marker in seg for marker in _OFFLINE_MARKERS):
+                continue
+            for pattern, label in _VIOLATION_PATTERNS:
+                if pattern.search(seg):
+                    violations.append(TestNetworkViolation(i, seg, label))
+                    break  # one violation per segment is enough
+    return violations
+
+
+def find_test_network_violations(task_dir: Path) -> list[TestNetworkViolation]:
+    """Scan a task's ``tests/test.sh`` for offline-policy violations.
+
+    Returns an empty list if the file does not exist (nothing to check) or is
+    clean.
+    """
+    test_sh = Path(task_dir) / "tests" / "test.sh"
+    if not test_sh.exists():
+        return []
+    text = test_sh.read_text(encoding="utf-8", errors="ignore")
+    return scan_test_script(text)
+
+
+def format_violations(task_dir: Path, violations: list[TestNetworkViolation]) -> str:
+    """Human-readable multi-line message describing violations."""
+    header = (
+        f"tests/test.sh in '{Path(task_dir).name}' installs dependencies or accesses "
+        "the network at test time. This is forbidden by the offline-tests policy: "
+        "all dependencies/tools/builds must be in the Dockerfile (build time), and the "
+        "verifier runs with no network (allow_internet=false)."
+    )
+    body = "\n".join(str(v) for v in violations)
+    return f"{header}\n{body}"
+
+
+def _main(argv: list[str]) -> int:
+    """CLI/pre-commit entry: scan task dir(s) or a dataset root; exit 1 on violations."""
+    if not argv:
+        print("usage: python -m swegen.tools.policy <task_dir | dataset_dir> ...", file=sys.stderr)
+        return 2
+
+    # Expand each argument: a task dir (has tests/test.sh) is checked directly;
+    # otherwise treat it as a dataset root and check each task subdirectory.
+    task_dirs: list[Path] = []
+    for arg in argv:
+        p = Path(arg)
+        if (p / "tests" / "test.sh").exists():
+            task_dirs.append(p)
+        elif p.is_dir():
+            task_dirs.extend(
+                d for d in sorted(p.iterdir()) if (d / "tests" / "test.sh").exists()
+            )
+
+    had_violation = False
+    for task_dir in task_dirs:
+        violations = find_test_network_violations(task_dir)
+        if violations:
+            had_violation = True
+            print(format_violations(task_dir, violations), file=sys.stderr)
+    if not task_dirs:
+        print("policy: no tasks with tests/test.sh found in given paths", file=sys.stderr)
+    return 1 if had_violation else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main(sys.argv[1:]))

--- a/src/swegen/tools/validate.py
+++ b/src/swegen/tools/validate.py
@@ -14,6 +14,7 @@ from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn
 from rich.table import Table
 
 from .harbor_runner import parse_harbor_outcome, run_harbor_agent
+from .policy import find_test_network_violations, format_violations
 
 DOCKER_CLEANUP_CMD = "docker system prune -af"
 
@@ -32,6 +33,7 @@ class ValidateArgs:
     show_passed: bool = False
     output_file: Path | None = None  # Write results to file as they complete
     docker_prune_batch: int = 5  # Run docker cleanup after every N tasks (0 to disable)
+    enforce_offline_tests: bool = True  # Fail tasks whose test.sh installs/network at test time
 
 
 @dataclass
@@ -98,6 +100,14 @@ def _run_single_mode(args: ValidateArgs, dataset_path: Path, task_id: str, task_
     """Validate a single task with traditional output."""
     jobs_dir = args.jobs_dir.resolve()
     jobs_dir.mkdir(parents=True, exist_ok=True)
+
+    # Offline-tests policy gate (fail fast before spinning up Docker).
+    if args.enforce_offline_tests:
+        violations = find_test_network_violations(task_dir)
+        if violations:
+            print("\n[validate] FAILED: offline-tests policy violation")
+            print(format_violations(task_dir, violations))
+            sys.exit(1)
 
     # Run regular validation
     print("[validate] Running regular validation...")
@@ -202,6 +212,7 @@ def _run_batch_mode(args: ValidateArgs, dataset_path: Path) -> None:
             console,
             args.output_file,
             args.docker_prune_batch,
+            args.enforce_offline_tests,
         )
     )
 
@@ -224,6 +235,7 @@ async def _validate_batch(
     console: Console,
     output_file: Path | None = None,
     docker_prune_batch: int = 5,
+    enforce_offline_tests: bool = True,
 ) -> list[ValidationResult]:
     """Run validations in parallel with progress bar."""
     semaphore = asyncio.Semaphore(max_parallel)
@@ -255,6 +267,22 @@ async def _validate_batch(
     async def validate_one(task_dir: Path) -> ValidationResult:
         async with semaphore:
             try:
+                # Offline-tests policy gate (static, no Docker needed).
+                if enforce_offline_tests:
+                    violations = find_test_network_violations(task_dir)
+                    if violations:
+                        result = ValidationResult(
+                            task_id=task_dir.name,
+                            nop_reward=None,
+                            oracle_reward=None,
+                            nop_exit_code=-1,
+                            oracle_exit_code=-1,
+                            passed=False,
+                            error="offline-tests policy: test.sh installs/network at test time",
+                        )
+                        await write_result(result)
+                        return result
+
                 nop_reward = oracle_reward = None
                 nop_code = oracle_code = 0
 


### PR DESCRIPTION
Opt-out `enforce_offline_tests` policy (default on) so a generated task's verifier runs with no network. Internet stays available only during the Docker build.

- **Prevent:** CC prompt gains an offline-tests constraint; the test.sh skeleton no longer suggests an install.
- **Detect (hard-fail):** new `tools/policy.py` scans `tests/test.sh` for installers/network (sparing `bundle exec`, `go test`, `pytest`, `--no-index`). Wired into create/validate/analyze.
- **Guarantee:** `task.toml` sets `[environment].allow_internet = false`.
- Toggle `--offline-tests/--allow-test-network`.

Targets harbor 0.1.41 (`allow_internet`). Introduces the shared `tools/policy.py` + toggle scaffolding.

_Merge order: after the two single-file PRs, before `feat/text-only-assets` (which extends `policy.py` and the same toggles)._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad CLI and pipeline behavior change (default stricter tasks); regex scanner may false-positive on unusual test.sh or miss edge cases, and existing tasks may fail until fixed or opted out.
> 
> **Overview**
> Introduces an **offline-tests policy** (on by default) so verifier runs have no network: deps and builds belong in the Dockerfile; `tests/test.sh` may only set env, copy tests, and invoke test runners.
> 
> **New `swegen.tools.policy`** statically scans `tests/test.sh` for installers and network fetches (`pip`/`npm`/`curl`/`git pull`, etc.), with narrow regexes and `--offline`/`--no-index` exemptions so commands like `go test` and `bundle exec` are not flagged. Exposes a `python -m swegen.tools.policy` CLI for CI/pre-commit.
> 
> **Generation:** skeleton `test.sh` documents the policy and drops install hints; `generate_task_toml` sets `[environment].allow_internet = false` when enforcement is on; Claude Code gets a hard-constraint prompt block. **Gates:** create fails fast with a panel before Harbor; validate (single and batch) and analyze quality check add the same violations to failures/issues.
> 
> **CLI/config:** `enforce_offline_tests` on `CreateConfig`/`FarmConfig`/`ValidateArgs`/`AnalyzeArgs`, wired through `create`, `farm`, `validate`, and `analyze` with **`--offline-tests` / `--allow-test-network`** to opt out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcbb37de53c42a891fd54b87e2d072d6de6ebce6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->