### PR TITLE
Enforce text-only instructions (non-multimodal solvable tasks)

### DIFF
--- a/src/swegen/analyze/run.py
+++ b/src/swegen/analyze/run.py
@@ -31,6 +31,7 @@ from swegen.tools.harbor_runner import (
     parse_harbor_outcome,
     run_harbor_agent,
 )
+from swegen.tools.policy import find_instruction_text_violations
 
 
 def _setup_claude_auth_preference(console: Console) -> None:
@@ -304,6 +305,10 @@ def _run_quality_check(
                     parts = [p.strip() for p in clean_line.split("│")]
                     if len(parts) >= 2 and any(k in parts[1].lower() for k in ["fail"]):
                         issues.append(parts[0])
+
+    # Text-only assets policy: instruction.md must be plain text (no images/diagrams/PDFs).
+    for v in find_instruction_text_violations(task_path):
+        issues.append(f"text-only: instruction.md {v.label} (line {v.line_number})")
 
     passed = proc.returncode == 0 and len(issues) == 0
 

--- a/src/swegen/analyze/run.py
+++ b/src/swegen/analyze/run.py
@@ -130,6 +130,7 @@ class AnalyzeArgs:
     timeout_multiplier: float = 1.0
     classification_timeout: int = 300  # Timeout per classification in seconds (5 min default)
     verdict_timeout: int = 180  # Timeout for verdict synthesis in seconds (3 min default)
+    enforce_text_only_assets: bool = True  # Flag instruction.md visual/binary refs in quality check
 
 
 def run_analyze(args: AnalyzeArgs) -> AnalysisResult:
@@ -183,7 +184,9 @@ def _run_analysis(
     quality_check = None
     if not args.skip_quality_check:
         console.print("\n[bold blue]Step 1/4: Static Quality Check[/bold blue]")
-        quality_check = _run_quality_check(task_path, args.analysis_model, console)
+        quality_check = _run_quality_check(
+            task_path, args.analysis_model, console, args.enforce_text_only_assets
+        )
     else:
         console.print("\n[dim]Step 1/4: Static Quality Check (skipped)[/dim]")
 
@@ -276,6 +279,7 @@ def _run_quality_check(
     task_path: Path,
     model: str,
     console: Console,
+    enforce_text_only_assets: bool = True,
 ) -> QualityCheckResult:
     """Run Harbor's static quality check on the task."""
     cmd = harbor_cmd_base() + [
@@ -307,8 +311,10 @@ def _run_quality_check(
                         issues.append(parts[0])
 
     # Text-only assets policy: instruction.md must be plain text (no images/diagrams/PDFs).
-    for v in find_instruction_text_violations(task_path):
-        issues.append(f"text-only: instruction.md {v.label} (line {v.line_number})")
+    # Respect the same opt-out as create/validate/farm (--allow-non-text-assets).
+    if enforce_text_only_assets:
+        for v in find_instruction_text_violations(task_path):
+            issues.append(f"text-only: instruction.md {v.label} (line {v.line_number})")
 
     passed = proc.returncode == 0 and len(issues) == 0
 

--- a/src/swegen/cli.py
+++ b/src/swegen/cli.py
@@ -92,6 +92,12 @@ def create_cmd(
         False,
         help="Allow processing unmerged PRs (for testing/preview); --allow-unmerged to enable",
     ),
+    enforce_text_only_assets: bool = typer.Option(
+        True,
+        "--text-only-assets/--allow-non-text-assets",
+        help="Require instruction.md to be plain text (no images/diagrams/PDFs to view), so the "
+        "task is solvable by a non-multimodal model; --allow-non-text-assets to disable",
+    ),
     environment: str = typer.Option(
         "docker",
         "-e",
@@ -118,6 +124,7 @@ def create_cmd(
         allow_unmerged=allow_unmerged,
         environment=EnvironmentType(environment),
         generate_name=generate_name,
+        enforce_text_only_assets=enforce_text_only_assets,
         verbose=verbose,
         quiet=quiet,
     )
@@ -174,6 +181,12 @@ def validate(
         help="Run docker cleanup after every N tasks (0 to disable, local docker only)",
         show_default=True,
     ),
+    enforce_text_only_assets: bool = typer.Option(
+        True,
+        "--text-only-assets/--allow-non-text-assets",
+        help="Fail tasks whose instruction.md references images/diagrams/PDFs (text-only policy); "
+        "--allow-non-text-assets to disable",
+    ),
 ) -> None:
     if agent not in ("both", "nop", "oracle"):
         raise typer.BadParameter("agent must be one of: both, nop, oracle")
@@ -191,6 +204,7 @@ def validate(
             show_passed=show_passed,
             output_file=output,
             docker_prune_batch=docker_prune_batch,
+            enforce_text_only_assets=enforce_text_only_assets,
         )
     )
 
@@ -381,6 +395,12 @@ def farm(
     validate: bool = typer.Option(
         True, help="Run Harbor validation after CC; --no-validate to skip"
     ),
+    enforce_text_only_assets: bool = typer.Option(
+        True,
+        "--text-only-assets/--allow-non-text-assets",
+        help="Require instruction.md to be plain text (no images/diagrams/PDFs to view), so the "
+        "task is solvable by a non-multimodal model; --allow-non-text-assets to disable",
+    ),
 ) -> None:
     """
     Continuously process merged GitHub PRs and convert them to Harbor tasks.
@@ -409,6 +429,7 @@ def farm(
         verbose=verbose,
         require_issue=require_issue,
         validate=validate,
+        enforce_text_only_assets=enforce_text_only_assets,
     )
 
     console = Console()

--- a/src/swegen/cli.py
+++ b/src/swegen/cli.py
@@ -278,6 +278,12 @@ def analyze(
         help="OpenAI model for verdict synthesis",
         show_default=True,
     ),
+    enforce_text_only_assets: bool = typer.Option(
+        True,
+        "--text-only-assets/--allow-non-text-assets",
+        help="Flag instruction.md images/diagrams/PDFs in the quality check; "
+        "--allow-non-text-assets to disable",
+    ),
 ) -> None:
     """
     Analyze a Harbor task to determine if it's well-specified.
@@ -326,6 +332,7 @@ def analyze(
             verbose=verbose,
             classification_timeout=classification_timeout,
             verdict_timeout=verdict_timeout,
+            enforce_text_only_assets=enforce_text_only_assets,
         )
     )
 

--- a/src/swegen/config.py
+++ b/src/swegen/config.py
@@ -31,6 +31,9 @@ class CreateConfig:
         allow_unmerged: Allow processing unmerged PRs (for testing/preview, default: False)
         environment: Environment type for Harbor runs (docker, daytona, e2b, modal, runloop, gke)
         generate_name: Generate semantic task name instead of PR number
+        enforce_text_only_assets: Require instruction.md to be plain text (no images/diagrams/PDFs
+            the agent must view), so the task is solvable by a non-multimodal model. Test files are
+            exempt (held out from the agent). Disable with --allow-non-text-assets.
         verbose: Increase output verbosity
         quiet: Reduce output verbosity
     """
@@ -50,6 +53,7 @@ class CreateConfig:
     allow_unmerged: bool = False
     environment: EnvironmentType = EnvironmentType.DOCKER
     generate_name: bool = False
+    enforce_text_only_assets: bool = True
     verbose: bool = False
     quiet: bool = False
 
@@ -90,6 +94,8 @@ class FarmConfig:
         verbose: Enable verbose output
         require_issue: Require PR to have a linked issue (higher quality instructions)
         validate: Run Harbor validation after CC (useful when CC times out but task may be valid)
+        enforce_text_only_assets: Require instruction.md to be plain text (see CreateConfig).
+            Disable with --allow-non-text-assets.
     """
 
     repo: str
@@ -113,6 +119,7 @@ class FarmConfig:
     verbose: bool = False
     require_issue: bool = True
     validate: bool = True
+    enforce_text_only_assets: bool = True
 
 
 @dataclass(frozen=True)

--- a/src/swegen/create/create.py
+++ b/src/swegen/create/create.py
@@ -18,6 +18,7 @@ from rich.traceback import install as rich_traceback_install
 
 from swegen.config import CreateConfig
 from swegen.tools.harbor_runner import parse_harbor_outcome, run_harbor_agent
+from swegen.tools.policy import find_instruction_text_violations, format_text_only_violations
 from swegen.tools.validate_utils import ValidationError, run_nop_oracle
 
 from . import MissingIssueError, PRToHarborPipeline, TrivialPRError
@@ -639,6 +640,24 @@ def run_reversal(config: CreateConfig) -> None:
         _handle_validation_failure(
             console, harbor_validation_failed, cc_validation_failed, harbor_actually_ran
         )
+
+        # Text-only assets policy gate: instruction.md must be plain text (no images/diagrams/PDFs
+        # to view), so the task is solvable by a non-multimodal model.
+        if config.enforce_text_only_assets:
+            text_violations = find_instruction_text_violations(task_dir)
+            if text_violations:
+                console.print()
+                console.print(
+                    Panel(
+                        Text(format_text_only_violations(task_dir, text_violations), style="red"),
+                        title="[red]Text-Only Assets Policy Violation[/red]",
+                        border_style="red",
+                    )
+                )
+                raise ValidationError(
+                    "instruction.md references images/diagrams/PDFs (text-only policy). "
+                    "Rewrite the instruction to convey all information as text."
+                )
 
         # Save state record (non-fatal if fails)
         _save_state_record(

--- a/src/swegen/create/create.py
+++ b/src/swegen/create/create.py
@@ -578,6 +578,27 @@ def run_reversal(config: CreateConfig) -> None:
 
         # Task ID from generated dir
         task_id = task_dir.name
+
+        # Text-only assets policy gate: instruction.md must be plain text (no images/diagrams/PDFs
+        # to view), so the task is solvable by a non-multimodal model. Run this BEFORE Harbor
+        # validation so we (a) fail fast without spinning up Docker, and (b) always report the
+        # violation even when NOP/Oracle or CC checks would otherwise fail first.
+        if config.enforce_text_only_assets:
+            text_violations = find_instruction_text_violations(task_dir)
+            if text_violations:
+                console.print()
+                console.print(
+                    Panel(
+                        Text(format_text_only_violations(task_dir, text_violations), style="red"),
+                        title="[red]Text-Only Assets Policy Violation[/red]",
+                        border_style="red",
+                    )
+                )
+                raise ValidationError(
+                    "instruction.md references images/diagrams/PDFs (text-only policy). "
+                    "Rewrite the instruction to convey all information as text."
+                )
+
         harbor_do = not config.no_validate
 
         # If CC already validated successfully, skip harbor validation
@@ -640,24 +661,6 @@ def run_reversal(config: CreateConfig) -> None:
         _handle_validation_failure(
             console, harbor_validation_failed, cc_validation_failed, harbor_actually_ran
         )
-
-        # Text-only assets policy gate: instruction.md must be plain text (no images/diagrams/PDFs
-        # to view), so the task is solvable by a non-multimodal model.
-        if config.enforce_text_only_assets:
-            text_violations = find_instruction_text_violations(task_dir)
-            if text_violations:
-                console.print()
-                console.print(
-                    Panel(
-                        Text(format_text_only_violations(task_dir, text_violations), style="red"),
-                        title="[red]Text-Only Assets Policy Violation[/red]",
-                        border_style="red",
-                    )
-                )
-                raise ValidationError(
-                    "instruction.md references images/diagrams/PDFs (text-only policy). "
-                    "Rewrite the instruction to convey all information as text."
-                )
 
         # Save state record (non-fatal if fails)
         _save_state_record(

--- a/src/swegen/create/task_instruction.py
+++ b/src/swegen/create/task_instruction.py
@@ -79,6 +79,15 @@ Instead, write as if describing the problem from a user/issue perspective:
 
 The agent solving this task will NOT see the test files, so any reference to them will be confusing.
 
+TEXT-ONLY (IMPORTANT):
+The instruction must be PLAIN TEXT, solvable by a non-multimodal model. Do NOT include or rely on
+images, screenshots, diagrams, charts, PDFs, or other visual/binary assets:
+✗ No markdown image embeds `![...](...)`, `<img>`/`<svg>` tags, or `data:` URIs
+✗ No links to image/PDF/video files (e.g. .png, .jpg, .svg, .pdf)
+✗ No "see the screenshot/diagram/figure/attached image" — the agent cannot view it
+If the issue/PR conveys information via an image or diagram, describe that information in words
+(e.g. the error text, the expected layout, the values) instead of referencing the visual.
+
 WHAT TO INCLUDE:
 ✓ Problem description from issue/PR
 ✓ Expected behavior vs actual behavior

--- a/src/swegen/farm/farm_hand.py
+++ b/src/swegen/farm/farm_hand.py
@@ -218,6 +218,7 @@ def _run_reversal_for_pr_impl(
         max_source_files=config.max_source_files,
         require_issue=config.require_issue,
         environment=config.environment,
+        enforce_text_only_assets=config.enforce_text_only_assets,
     )
 
     # Capture any errors from the pipeline

--- a/src/swegen/tools/policy.py
+++ b/src/swegen/tools/policy.py
@@ -35,8 +35,10 @@ _TEXT_ONLY_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"!\[[^\]]*\]\([^)]*\)"), "markdown image embed"),
     # HTML <img> / <picture> / <svg> / <video> / <embed> / <object>
     (re.compile(r"<\s*(img|picture|svg|video|embed|object)\b", re.IGNORECASE), "HTML visual element"),
-    # data: URI carrying an image/pdf/binary payload
-    (re.compile(r"data:(?:image|application|video)/[^;\s)]+;base64", re.IGNORECASE), "embedded data: URI"),
+    # data: URI carrying an embedded image, video, or PDF payload. Note: application/* is
+    # restricted to PDF so text MIME types (application/json, application/xml, ...) don't match.
+    (re.compile(r"data:(?:image/[^;,\s]+|video/[^;,\s]+|application/pdf);base64", re.IGNORECASE),
+     "embedded image/video/pdf data URI"),
     # Markdown link whose target is a visual/binary asset: [txt](foo.png)
     (re.compile(rf"\]\(\s*[^)\s]+\.(?:{_EXT_ALT})\b", re.IGNORECASE), "link to a visual/binary asset"),
     # Bare URL ending in a visual/binary asset extension
@@ -111,14 +113,21 @@ def _main(argv: list[str]) -> int:
                 d for d in sorted(p.iterdir()) if (d / "instruction.md").exists()
             )
 
+    # No resolvable tasks almost always means a wrong/empty path argument; exit non-zero
+    # (distinct from the violation code) so pre-commit/CI don't treat it as a passing scan.
+    if not task_dirs:
+        print(
+            "policy: no tasks with instruction.md found in given paths (check the path)",
+            file=sys.stderr,
+        )
+        return 2
+
     had_violation = False
     for task_dir in task_dirs:
         violations = find_instruction_text_violations(task_dir)
         if violations:
             had_violation = True
             print(format_text_only_violations(task_dir, violations), file=sys.stderr)
-    if not task_dirs:
-        print("policy: no tasks with instruction.md found in given paths", file=sys.stderr)
     return 1 if had_violation else 0
 
 

--- a/src/swegen/tools/policy.py
+++ b/src/swegen/tools/policy.py
@@ -1,0 +1,126 @@
+"""Static task-policy checks.
+
+Currently enforces the *text-only assets* policy:
+
+    Task instructions must be plain text so the task is solvable by a
+    non-multimodal model. instruction.md must NOT embed or link images,
+    diagrams, screenshots, PDFs, or other binary/visual assets that the agent
+    would have to *see* to solve the task — everything it needs must be conveyed
+    as text.
+
+Note: test files and fixtures are intentionally NOT checked — they are held out
+and never shown to the agent, so a binary test fixture (e.g. a PNG the code
+parses) does not make the task multimodal.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# File extensions that require visual/binary interpretation (not plain text).
+# SVG is technically text but encodes a diagram, so it's treated as visual.
+_VISUAL_EXTS = (
+    "png", "jpg", "jpeg", "gif", "bmp", "tif", "tiff", "webp", "ico", "svg",
+    "pdf", "mp4", "mov", "avi", "webm", "mkv", "psd", "sketch", "fig",
+)
+
+_EXT_ALT = "|".join(_VISUAL_EXTS)
+
+# (compiled regex, label). Matched against the raw instruction text.
+_TEXT_ONLY_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # Markdown image embed: ![alt](url)
+    (re.compile(r"!\[[^\]]*\]\([^)]*\)"), "markdown image embed"),
+    # HTML <img> / <picture> / <svg> / <video> / <embed> / <object>
+    (re.compile(r"<\s*(img|picture|svg|video|embed|object)\b", re.IGNORECASE), "HTML visual element"),
+    # data: URI carrying an image/pdf/binary payload
+    (re.compile(r"data:(?:image|application|video)/[^;\s)]+;base64", re.IGNORECASE), "embedded data: URI"),
+    # Markdown link whose target is a visual/binary asset: [txt](foo.png)
+    (re.compile(rf"\]\(\s*[^)\s]+\.(?:{_EXT_ALT})\b", re.IGNORECASE), "link to a visual/binary asset"),
+    # Bare URL ending in a visual/binary asset extension
+    (re.compile(rf"https?://\S+\.(?:{_EXT_ALT})\b", re.IGNORECASE), "URL to a visual/binary asset"),
+]
+
+
+@dataclass(frozen=True)
+class TextOnlyViolation:
+    """A single non-text reference found in instruction.md."""
+
+    line_number: int
+    line: str
+    label: str
+
+    def __str__(self) -> str:
+        return f"  line {self.line_number}: {self.label}  ->  {self.line.strip()}"
+
+
+def scan_instruction_text(text: str) -> list[TextOnlyViolation]:
+    """Scan instruction text for non-text (visual/binary) references.
+
+    Pure function over the instruction contents so it is easy to unit-test.
+    """
+    violations: list[TextOnlyViolation] = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            continue
+        for pattern, label in _TEXT_ONLY_PATTERNS:
+            if pattern.search(line):
+                violations.append(TextOnlyViolation(i, line, label))
+                break  # one violation per line is enough
+    return violations
+
+
+def find_instruction_text_violations(task_dir: Path) -> list[TextOnlyViolation]:
+    """Scan a task's ``instruction.md`` for text-only-policy violations.
+
+    Returns an empty list if the file does not exist or is clean.
+    """
+    instruction = Path(task_dir) / "instruction.md"
+    if not instruction.exists():
+        return []
+    text = instruction.read_text(encoding="utf-8", errors="ignore")
+    return scan_instruction_text(text)
+
+
+def format_text_only_violations(task_dir: Path, violations: list[TextOnlyViolation]) -> str:
+    """Human-readable multi-line message describing violations."""
+    header = (
+        f"instruction.md in '{Path(task_dir).name}' references images/diagrams/PDFs or other "
+        "visual/binary assets. This violates the text-only policy: instructions must be plain "
+        "text solvable by a non-multimodal model — convey all needed information as text."
+    )
+    body = "\n".join(str(v) for v in violations)
+    return f"{header}\n{body}"
+
+
+def _main(argv: list[str]) -> int:
+    """CLI/pre-commit entry: scan task dir(s) or a dataset root; exit 1 on violations."""
+    if not argv:
+        print("usage: python -m swegen.tools.policy <task_dir | dataset_dir> ...", file=sys.stderr)
+        return 2
+
+    task_dirs: list[Path] = []
+    for arg in argv:
+        p = Path(arg)
+        if (p / "instruction.md").exists():
+            task_dirs.append(p)
+        elif p.is_dir():
+            task_dirs.extend(
+                d for d in sorted(p.iterdir()) if (d / "instruction.md").exists()
+            )
+
+    had_violation = False
+    for task_dir in task_dirs:
+        violations = find_instruction_text_violations(task_dir)
+        if violations:
+            had_violation = True
+            print(format_text_only_violations(task_dir, violations), file=sys.stderr)
+    if not task_dirs:
+        print("policy: no tasks with instruction.md found in given paths", file=sys.stderr)
+    return 1 if had_violation else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main(sys.argv[1:]))

--- a/src/swegen/tools/validate.py
+++ b/src/swegen/tools/validate.py
@@ -14,6 +14,7 @@ from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn
 from rich.table import Table
 
 from .harbor_runner import parse_harbor_outcome, run_harbor_agent
+from .policy import find_instruction_text_violations, format_text_only_violations
 
 DOCKER_CLEANUP_CMD = "docker system prune -af"
 
@@ -32,6 +33,7 @@ class ValidateArgs:
     show_passed: bool = False
     output_file: Path | None = None  # Write results to file as they complete
     docker_prune_batch: int = 5  # Run docker cleanup after every N tasks (0 to disable)
+    enforce_text_only_assets: bool = True  # Fail tasks whose instruction.md references images/PDFs
 
 
 @dataclass
@@ -98,6 +100,14 @@ def _run_single_mode(args: ValidateArgs, dataset_path: Path, task_id: str, task_
     """Validate a single task with traditional output."""
     jobs_dir = args.jobs_dir.resolve()
     jobs_dir.mkdir(parents=True, exist_ok=True)
+
+    # Text-only assets policy gate (fail fast before spinning up Docker).
+    if args.enforce_text_only_assets:
+        violations = find_instruction_text_violations(task_dir)
+        if violations:
+            print("\n[validate] FAILED: text-only assets policy violation")
+            print(format_text_only_violations(task_dir, violations))
+            sys.exit(1)
 
     # Run regular validation
     print("[validate] Running regular validation...")
@@ -202,6 +212,7 @@ def _run_batch_mode(args: ValidateArgs, dataset_path: Path) -> None:
             console,
             args.output_file,
             args.docker_prune_batch,
+            args.enforce_text_only_assets,
         )
     )
 
@@ -224,6 +235,7 @@ async def _validate_batch(
     console: Console,
     output_file: Path | None = None,
     docker_prune_batch: int = 5,
+    enforce_text_only_assets: bool = True,
 ) -> list[ValidationResult]:
     """Run validations in parallel with progress bar."""
     semaphore = asyncio.Semaphore(max_parallel)
@@ -255,6 +267,20 @@ async def _validate_batch(
     async def validate_one(task_dir: Path) -> ValidationResult:
         async with semaphore:
             try:
+                # Text-only assets policy gate (static, no Docker needed).
+                if enforce_text_only_assets and find_instruction_text_violations(task_dir):
+                    result = ValidationResult(
+                        task_id=task_dir.name,
+                        nop_reward=None,
+                        oracle_reward=None,
+                        nop_exit_code=-1,
+                        oracle_exit_code=-1,
+                        passed=False,
+                        error="text-only policy: instruction.md references images/diagrams/PDFs",
+                    )
+                    await write_result(result)
+                    return result
+
                 nop_reward = oracle_reward = None
                 nop_code = oracle_code = 0
 


### PR DESCRIPTION
Opt-out `enforce_text_only_assets` policy (default on): `instruction.md` must be plain text (no images/diagrams/screenshots/PDFs to view), so the task is solvable by a non-multimodal model. **Test files are exempt** — they're held out from the agent, so binary fixtures don't make a task multimodal.

- **Prevent:** TEXT-ONLY section in the instruction-generation prompt.
- **Detect (hard-fail):** `tools/policy.py::find_instruction_text_violations()` scans `instruction.md` for image embeds/`<img>`/`data:` URIs/links to visual assets. Wired into create/validate/analyze.
- Toggle `--text-only-assets/--allow-non-text-assets`.

_Merge LAST: overlaps `feat/offline-tests-policy` (combine `tools/policy.py`; both add toggles to config/cli/create/validate/analyze/farm_hand) and `feat/absolute-path-instructions` (both edit the instruction system prompt)._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static checks and CLI flags on task generation/validation paths; no auth or runtime behavior changes beyond failing tasks that violate the policy.
> 
> **Overview**
> Adds a **text-only assets** policy (on by default) so Harbor tasks stay solvable without vision: `instruction.md` must not embed or link images, diagrams, PDFs, or similar assets agents would need to view. Test fixtures are intentionally out of scope.
> 
> **Prevention:** The instruction-generation system prompt gains a **TEXT-ONLY** section telling the model to describe visual information in prose instead of referencing screenshots or diagrams.
> 
> **Detection:** New `swegen.tools.policy` scans `instruction.md` with regex rules (markdown images, HTML media tags, `data:` URIs, links/URLs to visual file types) and exposes a small CLI for CI/pre-commit.
> 
> **Enforcement:** **create** fails fast with a rich error before Harbor/Docker; **validate** (single and batch) rejects violating tasks statically; **analyze** adds matching findings to the Harbor quality-check step. **create**, **validate**, **analyze**, and **farm** share `--text-only-assets` / `--allow-non-text-assets` via `CreateConfig` / `FarmConfig` / `ValidateArgs` / `AnalyzeArgs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f3437251b551fd4de5c0d4e52a98160fe68c64c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->