### PR TITLE
chore: upgrade pipeline models (gpt-5.5, Opus 4.8)

### DIFF
--- a/src/swegen/analyze/classifier.py
+++ b/src/swegen/analyze/classifier.py
@@ -28,7 +28,7 @@ from .models import (
 
 
 # OpenAI verdict synthesis constants
-VERDICT_MODEL = "gpt-5.2"
+VERDICT_MODEL = "gpt-5.5"
 VERDICT_TIMEOUT = 120.0
 VERDICT_MAX_TOKENS = 4096
 
@@ -45,7 +45,7 @@ def classify_trial(
     trial_dir: str | Path,
     task_dir: str | Path,
     *,
-    model: str = "claude-sonnet-4-5",
+    model: str = "claude-opus-4-8",
     verbose: bool = False,
     timeout: int = 300,
 ) -> TrialClassification:
@@ -67,7 +67,7 @@ def classify_trial(
     Args:
         trial_dir: Path to trial directory (contains result.json, agent/, verifier/)
         task_dir: Path to task directory (contains instruction.md, solution/, tests/)
-        model: Model name for Claude Code (default: claude-sonnet-4-5)
+        model: Model name for Claude Code (default: claude-opus-4-8)
         verbose: If True, stream Claude Code output to console
         timeout: Maximum time for classification in seconds (default: 300 = 5 min)
         
@@ -92,14 +92,14 @@ class TrialClassifier:
     
     def __init__(
         self,
-        model: str = "claude-sonnet-4-5",
+        model: str = "claude-opus-4-8",
         verbose: bool = False,
         timeout: int = 300,  # 5 minutes per classification
     ):
         """Initialize the classifier.
         
         Args:
-            model: Model name for Claude Code (default: claude-sonnet-4-5)
+            model: Model name for Claude Code (default: claude-opus-4-8)
             verbose: If True, stream Claude Code output to console
             timeout: Maximum time per classification in seconds (default: 300 = 5 min)
         """
@@ -436,7 +436,7 @@ def _compute_task_verdict_openai(
         classifications: List of individual trial classifications
         baseline: Optional baseline validation results
         quality_check_passed: Whether static quality check passed
-        model: OpenAI model to use (default: gpt-5.2)
+        model: OpenAI model to use (default: gpt-5.5)
         console: Optional console for progress output
         verbose: If True, print progress messages
         api_key: Optional OpenAI API key (defaults to OPENAI_API_KEY env var)
@@ -567,7 +567,7 @@ def compute_task_verdict(
         classifications: List of trial classifications
         baseline: Optional baseline validation results
         quality_check_passed: Whether static quality check passed
-        model: OpenAI model name (default: gpt-5.2)
+        model: OpenAI model name (default: gpt-5.5)
         console: Optional console for progress output
         verbose: If True, print progress messages
         api_key: Optional OpenAI API key (defaults to OPENAI_API_KEY env var)

--- a/src/swegen/analyze/run.py
+++ b/src/swegen/analyze/run.py
@@ -116,14 +116,14 @@ class AnalyzeArgs:
 
     task_path: Path
     agent: str = "claude-code"
-    model: str = "anthropic/claude-sonnet-4-5"
+    model: str = "anthropic/claude-sonnet-5"
     n_trials: int = 3
     n_concurrent: int = 1  # Number of concurrent trials (matches Harbor's -n flag)
     jobs_dir: Path = Path(".swegen/analyze-jobs")
     skip_quality_check: bool = False
     skip_baseline: bool = False  # Skip baseline validation (nop/oracle)
     skip_classify: bool = False  # Skip Claude Code classification
-    analysis_model: str = "claude-sonnet-4-5"  # Model for Claude Code classification
+    analysis_model: str = "claude-opus-4-8"  # Model for Claude Code classification
     verdict_model: str = VERDICT_MODEL  # OpenAI model for verdict synthesis
     environment: str = "docker"  # Environment type (docker|daytona|e2b|modal|runloop|gke)
     verbose: bool = False

--- a/src/swegen/analyze/run.py
+++ b/src/swegen/analyze/run.py
@@ -116,7 +116,7 @@ class AnalyzeArgs:
 
     task_path: Path
     agent: str = "claude-code"
-    model: str = "anthropic/claude-sonnet-5"
+    model: str = "anthropic/claude-opus-4-8"
     n_trials: int = 3
     n_concurrent: int = 1  # Number of concurrent trials (matches Harbor's -n flag)
     jobs_dir: Path = Path(".swegen/analyze-jobs")

--- a/src/swegen/cli.py
+++ b/src/swegen/cli.py
@@ -217,7 +217,7 @@ def analyze(
         "claude-code", "-a", "--agent", help="Agent to run trials with", show_default=True
     ),
     model: str = typer.Option(
-        "anthropic/claude-sonnet-4-5",
+        "anthropic/claude-sonnet-5",
         "-m",
         "--model",
         help="Model to use for agent trials",
@@ -245,7 +245,7 @@ def analyze(
         False, "--skip-classify", help="Skip LLM classification of trial outcomes"
     ),
     analysis_model: str = typer.Option(
-        "claude-sonnet-4-5",
+        "claude-opus-4-8",
         "--analysis-model",
         help="Model for Claude Code classification",
         show_default=True,

--- a/src/swegen/cli.py
+++ b/src/swegen/cli.py
@@ -217,7 +217,7 @@ def analyze(
         "claude-code", "-a", "--agent", help="Agent to run trials with", show_default=True
     ),
     model: str = typer.Option(
-        "anthropic/claude-sonnet-5",
+        "anthropic/claude-opus-4-8",
         "-m",
         "--model",
         help="Model to use for agent trials",

--- a/src/swegen/create/claude_code_runner.py
+++ b/src/swegen/create/claude_code_runner.py
@@ -916,7 +916,7 @@ async def _run_claude_code_session_async(
             allowed_tools=["Read", "Write", "Edit", "Glob", "Grep", "LS", "Bash"],
             permission_mode="bypassPermissions",  # Auto-approve actions
             cwd=os.getcwd(),  # Run from project root
-            model="sonnet",  # Use Sonnet model
+            model="claude-opus-4-8",  # Use Opus 4.8
             hooks={
                 "PreToolUse": [HookMatcher(matcher="Bash", hooks=[log_harbor_runs])]
             } if verbose else {},

--- a/src/swegen/create/task_instruction.py
+++ b/src/swegen/create/task_instruction.py
@@ -19,7 +19,7 @@ MAX_TOTAL_TEST_LENGTH = 10000  # Max total chars for all test files
 MIN_INSTRUCTION_LENGTH = 100
 OPENAI_API_TIMEOUT = 90.0
 MAX_COMPLETION_TOKENS = 4096
-MODEL_NAME = "gpt-5.2"
+MODEL_NAME = "gpt-5.5"
 DEBUG_REASON_TRUNCATE_LENGTH = 100
 
 COMBINED_SYSTEM_PROMPT = """You are evaluating GitHub pull requests and converting substantial ones into SWE-bench tasks.


### PR DESCRIPTION
Upgrades the models used across the pipeline.

## Changes
| Location | Purpose | Before | After |
|---|---|---|---|
| `create/task_instruction.py` | Instruction generation (OpenAI) | gpt-5.2 | **gpt-5.5** |
| `analyze/classifier.py` `VERDICT_MODEL` | Verdict synthesis (OpenAI) | gpt-5.2 | **gpt-5.5** |
| `create/claude_code_runner.py` | Claude Code session | sonnet | **Opus 4.8** (`claude-opus-4-8`) |
| `analyze/classifier.py` + `run.py`/`cli.py` `analysis_model` | Classification judge (Claude) | claude-sonnet-4-5 | **Opus 4.8** |
| `analyze/run.py` + `cli.py` trial `model` (harbor `-m`) | Trial agent | anthropic/claude-sonnet-4-5 | **anthropic/claude-opus-4-8** |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior and cost/latency may shift with stronger models, but changes are default string constants only with no control-flow or security logic touched.
> 
> **Overview**
> Updates **default model IDs** across create and analyze so new runs use newer models without passing flags.
> 
> **OpenAI (`gpt-5.2` → `gpt-5.5`):** `MODEL_NAME` in `task_instruction.py` for PR evaluation/instruction generation, and `VERDICT_MODEL` in `classifier.py` for task verdict synthesis (docstrings updated to match).
> 
> **Anthropic (Sonnet 4.5 → Opus 4.8):** `classify_trial` / `TrialClassifier` defaults and `AnalyzeArgs` / `swegen analyze` options for **trial agent** (`anthropic/claude-opus-4-8`) and **classification judge** (`claude-opus-4-8`). The create-path Claude Code SDK session in `claude_code_runner.py` switches from alias `"sonnet"` to **`claude-opus-4-8`**.
> 
> No changes to prompts, timeouts, or orchestration—only defaults and comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d0213e569c3fce50ee5c9a1b4740f32c178bc43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->