### PR TITLE
feat: publish generated tasks as PRs to a dataset repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,13 @@ push in `_finalize()` (which sets a nonzero exit code). Both are checked togethe
 abort that happens to hit both reports both — the panel never claims farm state was preserved
 when it was not. Non-publish failures (trivial, no-issue, validation) never abort.
 
+A **Claude rate/usage limit** also aborts (category `rate_limited`). Claude Code failures
+whose error matches a rate-limit signature — notably `rate_limit_event`, the SDK message
+that `claude-agent-sdk` fails to parse — are raised as `ClaudeRateLimitError` rather than
+swallowed into a validation failure. Every task draws from the same limit, so continuing is
+pointless until the token/account is swapped; the run stops and the source PR is left
+unprocessed so a re-run with a fresh token farms it. The abort panel says to swap the token.
+
 Tasks that fail to publish are **kept on disk** (unlike other failures, which are cleaned
 up): they passed every validation gate, so they are valid work that can be pushed by hand or
 by a re-run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,10 @@ prune/progress cadences are driven by a per-run `prs_seen` counter rather than
 
 `--reset` with `--publish-repo` overwrites the durable state branch, not just a local file —
 every PR recorded there gets regenerated. The farm prints a warning; the behavior is intended.
+The overwrite is honored even if the first state push is rejected by a concurrent writer: a
+reset run force-pushes rather than merging, or the merge would union the old PRs back in and
+silently undo the reset. Only the first save forces; later saves in the same run merge, so a
+legitimate concurrent writer is not clobbered on every PR.
 
 `GIT_TOKEN` is separate from `GITHUB_TOKEN` (read-only, used to fetch source PRs) so a farm
 run can read from anywhere while only ever writing to one repo. It falls back to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,9 @@ that rule — without `--force` the publish would fail on `git add` with "paths 
 Only the one `tasks/<task_id>/` pathspec is ever staged.
 
 **Publish failures stop the run.** A bad token fails at preflight, before any PR is
-processed. Once farming is underway, a fatal failure (token rejected, GitHub down, retries
+processed. Preflight rejects only an *explicit* `push: false` from `GET /repos`; fine-grained
+and app tokens may omit `permissions` entirely, so an absent field warns and proceeds rather
+than blocking a token whose pushes would have succeeded. Once farming is underway, a fatal failure (token rejected, GitHub down, retries
 exhausted against a 5xx or rate limit) aborts immediately — the next PR would spend a full
 Claude Code session only to hit the same wall. An ambiguous failure (a rejected `git push`
 looks identical whether the remote is broken or the task is) is tolerated once and aborts on

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,23 +115,28 @@ Tasks are staged with `git add --force`. SWE-gen's own `.gitignore` excludes `ta
 that rule — without `--force` the publish would fail on `git add` with "paths are ignored".
 Only the one `tasks/<task_id>/` pathspec is ever staged.
 
-**Publish failures stop the run.** A bad token fails at preflight, before any PR is
-processed. Preflight rejects only an *explicit* `push: false` from `GET /repos`; fine-grained
-and app tokens may omit `permissions` entirely, so an absent field warns and proceeds rather
-than blocking a token whose pushes would have succeeded. Once farming is underway, a fatal failure (token rejected, GitHub down, retries
-exhausted against a 5xx or rate limit) aborts immediately — the next PR would spend a full
-Claude Code session only to hit the same wall. An ambiguous failure (a rejected `git push`
-looks identical whether the remote is broken or the task is) is tolerated once and aborts on
-the second in a row. Non-publish failures never abort.
+**Publish failures stop the run — on the first one.** A bad token fails at preflight, before
+any PR is processed. Preflight rejects only an *explicit* `push: false` from `GET /repos`;
+fine-grained and app tokens may omit `permissions` entirely, so an absent field warns and
+proceeds rather than blocking a token whose pushes would have succeeded.
+
+Once farming is underway, any publish failure aborts: a rejected `git push` cannot be told
+apart from a broken remote, and the next PR would spend a full Claude Code session only to
+hit the same wall. A failed **state push** aborts for the same reason, including the final
+push in `_finalize()` (which sets a nonzero exit code). Both are checked together, so an
+abort that happens to hit both reports both — the panel never claims farm state was preserved
+when it was not. Non-publish failures (trivial, no-issue, validation) never abort.
 
 Tasks that fail to publish are **kept on disk** (unlike other failures, which are cleaned
 up): they passed every validation gate, so they are valid work that can be pushed by hand or
-by a re-run. Farm state is preserved, so a re-run does not regenerate already-processed PRs.
+by a re-run.
 
 The source PR is **not marked processed** on a publish failure, so a re-run retries it. This
 is the recovery path for a push that succeeds and a `create_pr` that then fails: the retry
-finds the stale branch, recommits, and opens the PR that never got created. Marking it
-processed would strand a branch on the remote with no PR and no way to reach it again.
+refreshes the branch this task left behind and opens the PR that never got created. Marking
+it processed would strand a branch on the remote with no PR and no way to reach it again.
+`StreamingPRFetcher` also exempts these PRs from the resume-time skip, so one sharing the
+cursor's timestamp is retried rather than stranded.
 
 That retry is **publish-only**: the farm republishes the task already on disk rather than
 regenerating it. Regeneration runs with `force=True`, which `rmtree`s the task directory
@@ -139,10 +144,8 @@ before rebuilding — throwing away a validated task to redo an hour of Claude C
 it outright if the rebuild then fails. If the task is missing (a fresh sandbox), the retry
 falls back to full generation.
 
-A failed **state push** is equally fatal and also stops the run, including the final push in
-`_finalize()` (which sets a nonzero exit code). If the state branch stops advancing, a
-resumed sandbox works from a stale cursor and repeats hours of Claude Code on PRs it already
-handled. The local mirror is still written, so nothing is lost from disk.
+When a state push fails, the local mirror has already been written, so nothing is lost from
+disk — but the durable cursor is behind, and the abort panel says so and names the mirror.
 
 If a state push is rejected because the remote moved, the loser **merges** rather than
 overwrites: `StreamState.merge_from` unions the processed-PR sets and keeps the newer cursor
@@ -155,9 +158,12 @@ on every mutation, never incremented in place. A PR can move between categories 
 failure that later succeeds on retry — and a merge unions two states; incremental counting
 drifts in both cases.
 
-`swegen create` publishes **before** writing its `create.jsonl` dedupe record. Recording a
-task that was never published would make the next run skip it as a duplicate, with no way to
-retry the publish short of `--force`.
+`swegen create` publishes **before** writing its `create.jsonl` dedupe record, and the record
+carries a `published` flag reflecting what actually reached the dataset repo — `false` under
+`--publish-dry-run`, and `false` when the publish raised, in which case the task is *still*
+recorded so a rerun's dedupe finds it and republishes rather than hitting `FileExistsError`
+and needing `--force`, which would delete it. Records written before this flag existed are
+read as published.
 
 A **dedupe hit publishes the existing task** rather than returning early. A task on disk is
 not proof it reached the dataset repo — it may predate publishing, or belong to a run whose
@@ -170,10 +176,18 @@ and returning early would leave the branch and PR on older content while the pip
 success. If the task is already merged into the base branch byte-for-byte there is nothing to
 commit, and publish reports success without pushing.
 
-`GitStateStore.load` merges the **local mirror** into the state branch. The mirror is written
-before every push, so a failed push leaves it ahead of the branch; reading only the remote
-would forget those PRs and drop `publish_failed_prs`, which the fetcher needs to know a PR
-still awaits its PR.
+`GitStateStore.load` merges the **local mirror** with the state branch, and the side with the
+newer `last_updated` is the merge receiver (ties favour the mirror). A failed push leaves the
+mirror ahead of the branch; another sandbox can equally leave the branch ahead of a mirror
+sitting on a persistent volume. Reading only one side would forget the other's PRs and drop
+`publish_failed_prs`, which the fetcher needs to know a PR still awaits its PR. Sets union
+whichever way the merge runs, so no PR is ever lost — the receiver only decides per-PR value
+collisions (`task_pr_urls`, `successful_prs`, `other_failed_prs`).
+
+**Dry runs record nothing.** `--dry-run` generates no task, and `--publish-dry-run` pushes
+nothing, so neither consumes a source PR — a later real run must still farm it. The
+prune/progress cadences are driven by a per-run `prs_seen` counter rather than
+`state.total_processed`, which a dry run leaves at zero.
 
 `--reset` with `--publish-repo` overwrites the durable state branch, not just a local file —
 every PR recorded there gets regenerated. The farm prints a warning; the behavior is intended.
@@ -506,9 +520,8 @@ Common error types:
 - **ValidationError** - Harbor NOP/Oracle validation failed
 - **FileExistsError** - Task already exists (use `--force`)
 
-- **PublishError** - Task-specific publish rejection; farming continues
-- **PublishFatalError** - Publishing is broken for every task (GitHub down, retries exhausted); farming stops
-- **PublishAuthError** - Publish token missing, invalid, or lacking write access (subclass of PublishFatalError)
+- **PublishError** - A task could not be published (push/PR failed, or a recorded task is missing from disk); farming stops
+- **PublishAuthError** - Publish token missing, invalid, or lacking write access; raised at preflight, never retried (subclass of PublishError)
 
 Farm mode classifies failures for reporting:
 - Trivial PR (skipped)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ Key options:
 - `--publish-state-path`: Default `state`
 - `--publish-clone-dir`: Default `<state-dir>/publish/<dataset_slug>/<source_slug>`
 - `--publish-dry-run`: Clone, branch and commit locally; never push or open a PR
+- `--cleanup-local`: Delete each local task copy once it is published to the dataset repo
 
 **Contract with the dataset repo:** task PRs touch only `tasks/<task_id>/`, so PRs from
 different source repos merge into `main` without conflict. Do **not** add a top-level
@@ -188,6 +189,21 @@ collisions (`task_pr_urls`, `successful_prs`, `other_failed_prs`).
 nothing, so neither consumes a source PR — a later real run must still farm it. The
 prune/progress cadences are driven by a per-run `prs_seen` counter rather than
 `state.total_processed`, which a dry run leaves at zero.
+
+**`--cleanup-local`** deletes each local task directory once it is durably published (a real
+branch/PR on the dataset repo), to free disk on constrained sandboxes. It never fires on a
+dry run, a publish failure, or when publishing is disabled — the dataset repo must be the
+surviving copy. Cleanup is the last step, after the state record and the task-reference save;
+the farm suppresses `run_reversal`'s own cleanup (`cleanup_local=False` in the generated
+config) so the task dir still exists for the success gate and the reference save, then cleans
+up itself. A genuinely missing task dir (a pipeline bug, not a cleanup) still fails the gate.
+
+**A task that exists on disk but not in the dataset repo is republished, not consumed.** If a
+farm run hits `FileExistsError` (a validated task dir survives but `create.jsonl` can't
+dedupe it — e.g. a `--publish-dry-run` built it, or `.swegen` was cleared) and publishing is
+on, the farm republishes the existing task via `publish_existing_task` rather than marking the
+PR `already_exists` and moving on unpublished. If that republish fails it becomes
+`publish_failed` (task preserved), symmetric with the publish-only retry.
 
 `--reset` with `--publish-repo` overwrites the durable state branch, not just a local file —
 every PR recorded there gets regenerated. The farm prints a warning; the behavior is intended.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,9 +131,21 @@ is the recovery path for a push that succeeds and a `create_pr` that then fails:
 finds the stale branch, recommits, and opens the PR that never got created. Marking it
 processed would strand a branch on the remote with no PR and no way to reach it again.
 
-A failed **state push** is equally fatal and also stops the run. If the state branch stops
-advancing, a resumed sandbox works from a stale cursor and repeats hours of Claude Code on
-PRs it already handled. The local mirror is still written, so nothing is lost from disk.
+A failed **state push** is equally fatal and also stops the run, including the final push in
+`_finalize()` (which sets a nonzero exit code). If the state branch stops advancing, a
+resumed sandbox works from a stale cursor and repeats hours of Claude Code on PRs it already
+handled. The local mirror is still written, so nothing is lost from disk.
+
+If a state push is rejected because the remote moved, the loser **merges** rather than
+overwrites: `StreamState.merge_from` unions the processed-PR sets and keeps the newer cursor
+(newer skips less; `processed_prs` is the authoritative skip list). Blindly recommitting an
+in-memory snapshot would erase whatever the other writer just published. One container per
+repo means this should never trigger, but losing a durable cursor is not worth the gamble.
+
+Counters (`successful` / `failed` / `total_processed`) are **derived** from the recorded sets
+on every mutation, never incremented in place. A PR can move between categories — a publish
+failure that later succeeds on retry — and a merge unions two states; incremental counting
+drifts in both cases.
 
 `swegen create` publishes **before** writing its `create.jsonl` dedupe record. Recording a
 task that was never published would make the next run skip it as a duplicate, with no way to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,61 @@ Key options:
 - `--no-validate`: Skip Harbor validation
 - `--skip-list PATH`: Path to file with task IDs to skip (one per line)
 
+### Publishing tasks (ephemeral sandboxes)
+
+Both `create` and `farm` can publish each validated task to a **dataset repo** as its own
+branch + PR, immediately. This is what makes farming safe on ephemeral sandboxes like
+Daytona: nothing of value lives only on local disk.
+
+```bash
+export GIT_TOKEN=<token>   # contents:write + pull_requests:write on the dataset repo
+swegen farm fastapi/fastapi --publish-repo abundant-ai/ots-tasks
+```
+
+Per validated task: a branch `task/<task_id>` is cut fresh from `main`, the task directory
+is copied to `tasks/<task_id>`, committed as `Add task: <task_id>`, pushed, and opened as a
+PR whose body links back to the source PR.
+
+Farm state is committed to a **per-source-repo branch** `farm-state/<owner>__<repo>` on the
+same dataset repo after every PR, so a fresh sandbox resumes exactly where the dead one
+stopped rather than re-burning Claude Code and OpenAI calls on PRs it already rejected.
+Per-repo branch names mean N containers farming N repos never contend.
+
+Key options:
+- `--publish-repo`: Dataset repo (`owner/repo`). Its presence enables publishing.
+- `--publish-path`: Directory within the dataset repo (default: `tasks`)
+- `--publish-base`: Branch task branches are cut from and PRs target (default: `main`)
+- `--publish-branch-prefix`: Default `task/`
+- `--publish-state-branch-prefix`: Default `farm-state/`
+- `--publish-state-path`: Default `state`
+- `--publish-clone-dir`: Default `<state-dir>/publish/<dataset_slug>/<source_slug>`
+- `--publish-dry-run`: Clone, branch and commit locally; never push or open a PR
+
+**Contract with the dataset repo:** task PRs touch only `tasks/<task_id>/`, so PRs from
+different source repos merge into `main` without conflict. Do **not** add a top-level
+manifest or a README table of tasks — it would textually conflict on every merge. Generate
+any such index in CI from the directory listing instead.
+
+Tasks are staged with `git add --force`. SWE-gen's own `.gitignore` excludes `tasks/`
+(it is the local output directory), and a dataset repo created from this template inherits
+that rule — without `--force` the publish would fail on `git add` with "paths are ignored".
+Only the one `tasks/<task_id>/` pathspec is ever staged.
+
+**Publish failures stop the run.** A bad token fails at preflight, before any PR is
+processed. Once farming is underway, a fatal failure (token rejected, GitHub down, retries
+exhausted against a 5xx or rate limit) aborts immediately — the next PR would spend a full
+Claude Code session only to hit the same wall. An ambiguous failure (a rejected `git push`
+looks identical whether the remote is broken or the task is) is tolerated once and aborts on
+the second in a row. Non-publish failures never abort.
+
+Tasks that fail to publish are **kept on disk** (unlike other failures, which are cleaned
+up): they passed every validation gate, so they are valid work that can be pushed by hand or
+by a re-run. Farm state is preserved, so a re-run does not regenerate already-processed PRs.
+
+`GIT_TOKEN` is separate from `GITHUB_TOKEN` (read-only, used to fetch source PRs) so a farm
+run can read from anywhere while only ever writing to one repo. It falls back to
+`GITHUB_TOKEN` if unset.
+
 ### `swegen validate`
 Validate existing Harbor tasks.
 
@@ -143,6 +198,15 @@ src/swegen/
 │   ├── farm_hand.py        # Per-PR processing logic
 │   ├── fetcher.py          # StreamingPRFetcher - GitHub PR streaming
 │   └── state.py            # StreamState - persistence for resumability
+├── publish/                # Publish tasks + farm state to a dataset repo
+│   ├── base.py             # TaskSink / StateStore protocols, PublishContext/Result
+│   ├── git_ops.py          # GitRepo - subprocess git wrapper (clone, branch, worktree)
+│   ├── gh_api.py           # GitHubAPI - REST client with bounded retries
+│   ├── github_pr.py        # GitHubPRSink - branch + PR per task
+│   ├── git_state.py        # GitStateStore - state on farm-state/<slug> branch
+│   ├── local_state.py      # LocalStateStore - state on local disk (default)
+│   ├── null.py             # NullSink - no publishing (default)
+│   └── body.py             # PR title/body/commit message templates
 └── tools/                  # Utility tools
     ├── validate.py         # Harbor NOP/Oracle validation
     ├── harbor_runner.py    # Harbor CLI wrapper
@@ -316,6 +380,7 @@ All configuration is done via dataclasses in `config.py`:
 - **CreateConfig** - Single PR → task conversion
 - **FarmConfig** - Continuous PR farming
 - **ValidateConfig** - Task validation
+- **PublishConfig** - Dataset repo, token, branch/path naming (None disables publishing)
 
 Key defaults:
 - Claude Code always used for task completion
@@ -341,8 +406,22 @@ State is persisted in `.swegen/`:
 ├── repos/              # Cached git repos
 ├── harbor-jobs/        # Harbor job artifacts
 ├── logs/               # Generation logs
+├── publish/            # Clone of the dataset repo (when --publish-repo is set)
+│   └── <dataset_slug>/<source_slug>/       # main tree: task branches
+│   └── <dataset_slug>/<source_slug>-state/ # linked worktree: state branch
 └── task_references.json    # Successful task references
 ```
+
+All of `.swegen/` is lost when an ephemeral sandbox dies. With `--publish-repo`, tasks and
+`StreamState` are mirrored to the dataset repo, which is the durable copy.
+
+The task branch and the state branch share one clone but live in **separate working trees**
+(`git worktree`), so the state push that follows every PR never disturbs the task branch
+being built in the main tree.
+
+Task publishing is serial-only: `StreamFarmer` processes one PR at a time, so a single
+working tree with `checkout -B` per task is safe. Concurrent generation within one process
+would need a worktree per task.
 
 ---
 
@@ -375,12 +454,17 @@ Common error types:
 - **ValidationError** - Harbor NOP/Oracle validation failed
 - **FileExistsError** - Task already exists (use `--force`)
 
+- **PublishError** - Task-specific publish rejection; farming continues
+- **PublishFatalError** - Publishing is broken for every task (GitHub down, retries exhausted); farming stops
+- **PublishAuthError** - Publish token missing, invalid, or lacking write access (subclass of PublishFatalError)
+
 Farm mode classifies failures for reporting:
 - Trivial PR (skipped)
 - No linked issue (skipped)
 - Validation failed
 - API rate limit exceeded
 - Git checkout failed
+- Publish failed
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,12 @@ is the recovery path for a push that succeeds and a `create_pr` that then fails:
 finds the stale branch, recommits, and opens the PR that never got created. Marking it
 processed would strand a branch on the remote with no PR and no way to reach it again.
 
+That retry is **publish-only**: the farm republishes the task already on disk rather than
+regenerating it. Regeneration runs with `force=True`, which `rmtree`s the task directory
+before rebuilding — throwing away a validated task to redo an hour of Claude Code, and losing
+it outright if the rebuild then fails. If the task is missing (a fresh sandbox), the retry
+falls back to full generation.
+
 A failed **state push** is equally fatal and also stops the run, including the final push in
 `_finalize()` (which sets a nonzero exit code). If the state branch stops advancing, a
 resumed sandbox works from a stale cursor and repeats hours of Claude Code on PRs it already

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,12 @@ not proof it reached the dataset repo — it may predate publishing, or belong t
 push failed. Returning silently would let the farm mark the source PR processed with no PR
 ever opened. Publishing is idempotent, so a task already published just yields its PR URL.
 
+An **already-open PR refreshes its branch**; it short-circuits only PR *creation*. The task
+may have been regenerated (`--force`, `--reset`, a rerun after a failed `create.jsonl` write),
+and returning early would leave the branch and PR on older content while the pipeline reported
+success. If the task is already merged into the base branch byte-for-byte there is nothing to
+commit, and publish reports success without pushing.
+
 `GitStateStore.load` merges the **local mirror** into the state branch. The mirror is written
 before every push, so a failed push leaves it ahead of the branch; reading only the remote
 would forget those PRs and drop `publish_failed_prs`, which the fetcher needs to know a PR

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,22 @@ Tasks that fail to publish are **kept on disk** (unlike other failures, which ar
 up): they passed every validation gate, so they are valid work that can be pushed by hand or
 by a re-run. Farm state is preserved, so a re-run does not regenerate already-processed PRs.
 
+The source PR is **not marked processed** on a publish failure, so a re-run retries it. This
+is the recovery path for a push that succeeds and a `create_pr` that then fails: the retry
+finds the stale branch, recommits, and opens the PR that never got created. Marking it
+processed would strand a branch on the remote with no PR and no way to reach it again.
+
+A failed **state push** is equally fatal and also stops the run. If the state branch stops
+advancing, a resumed sandbox works from a stale cursor and repeats hours of Claude Code on
+PRs it already handled. The local mirror is still written, so nothing is lost from disk.
+
+`swegen create` publishes **before** writing its `create.jsonl` dedupe record. Recording a
+task that was never published would make the next run skip it as a duplicate, with no way to
+retry the publish short of `--force`.
+
+`--reset` with `--publish-repo` overwrites the durable state branch, not just a local file —
+every PR recorded there gets regenerated. The farm prints a warning; the behavior is intended.
+
 `GIT_TOKEN` is separate from `GITHUB_TOKEN` (read-only, used to fetch source PRs) so a farm
 run can read from anywhere while only ever writing to one repo. It falls back to
 `GITHUB_TOKEN` if unset.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,9 @@ that `claude-agent-sdk` fails to parse — are raised as `ClaudeRateLimitError` 
 swallowed into a validation failure. Every task draws from the same limit, so continuing is
 pointless until the token/account is swapped; the run stops and the source PR is left
 unprocessed so a re-run with a fresh token farms it. The abort panel says to swap the token.
+The PR is recorded in `claude_rate_limited_prs` (not merely skipped) and exempted from the
+resume-time skip, exactly like `publish_failed_prs` — otherwise a PR sharing the resume
+cursor's exact `created_at` would be dropped by the fetcher's `>=` and never retried.
 
 Tasks that fail to publish are **kept on disk** (unlike other failures, which are cleaned
 up): they passed every validation gate, so they are valid work that can be pushed by hand or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,16 @@ drifts in both cases.
 task that was never published would make the next run skip it as a duplicate, with no way to
 retry the publish short of `--force`.
 
+A **dedupe hit publishes the existing task** rather than returning early. A task on disk is
+not proof it reached the dataset repo — it may predate publishing, or belong to a run whose
+push failed. Returning silently would let the farm mark the source PR processed with no PR
+ever opened. Publishing is idempotent, so a task already published just yields its PR URL.
+
+`GitStateStore.load` merges the **local mirror** into the state branch. The mirror is written
+before every push, so a failed push leaves it ahead of the branch; reading only the remote
+would forget those PRs and drop `publish_failed_prs`, which the fetcher needs to know a PR
+still awaits its PR.
+
 `--reset` with `--publish-repo` overwrites the durable state branch, not just a local file —
 every PR recorded there gets regenerated. The farm prints a warning; the behavior is intended.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "openai>=2.15.0",
     "pydantic>=2.12.5",
     "python-dotenv>=1.2.1",
-    "claude-agent-sdk>=0.1.20",
+    "claude-agent-sdk>=0.2.116",  # 0.1.x cannot parse rate_limit_event and kills the stream
     "harbor>=0.17.1",
 ]
 

--- a/src/swegen/cli.py
+++ b/src/swegen/cli.py
@@ -16,6 +16,7 @@ from swegen.create.create import run_reversal
 from swegen.farm import StreamFarmer
 from swegen.analyze import AnalyzeArgs, run_analyze
 from swegen.analyze.classifier import VERDICT_MODEL
+from swegen.create.claude_code_runner import ClaudeRateLimitError
 from swegen.publish import PublishError
 from swegen.tools.validate import ValidateArgs, run_validate
 from swegen.tools.validate_utils import ValidationError
@@ -239,6 +240,7 @@ def create_cmd(
         ValidationError,
         FileExistsError,
         PublishError,
+        ClaudeRateLimitError,
     ) as err:
         # These exceptions have already displayed user-friendly messages
         # Exit with error code but don't show traceback

--- a/src/swegen/cli.py
+++ b/src/swegen/cli.py
@@ -37,6 +37,7 @@ def _build_publish_config(
     publish_state_path: str,
     publish_clone_dir: Path | None,
     publish_dry_run: bool,
+    publish_cleanup_local: bool = False,
 ) -> PublishConfig | None:
     """Build a PublishConfig from CLI options, or None when publishing is off.
 
@@ -64,6 +65,7 @@ def _build_publish_config(
         state_path=publish_state_path,
         clone_dir=publish_clone_dir,
         dry_run=publish_dry_run,
+        cleanup_local=publish_cleanup_local,
         author_name=os.environ.get("GIT_AUTHOR_NAME", DEFAULT_AUTHOR_NAME),
         author_email=os.environ.get("GIT_AUTHOR_EMAIL", DEFAULT_AUTHOR_EMAIL),
     )
@@ -189,6 +191,12 @@ def create_cmd(
         "--publish-dry-run",
         help="Clone, branch and commit locally but never push or open a PR",
     ),
+    publish_cleanup_local: bool = typer.Option(
+        False,
+        "--cleanup-local",
+        help="Delete the local task copy once it is published to the dataset repo "
+        "(frees disk on constrained sandboxes; never deletes an unpublished task)",
+    ),
     verbose: bool = typer.Option(False, "-v", "--verbose", help="Increase output verbosity"),
     quiet: bool = typer.Option(False, "-q", "--quiet", help="Reduce output verbosity"),
 ) -> None:
@@ -218,6 +226,7 @@ def create_cmd(
             publish_state_path,
             publish_clone_dir,
             publish_dry_run,
+            publish_cleanup_local,
         ),
         verbose=verbose,
         quiet=quiet,
@@ -546,6 +555,12 @@ def farm(
         "--publish-dry-run",
         help="Clone, branch and commit locally but never push or open a PR",
     ),
+    publish_cleanup_local: bool = typer.Option(
+        False,
+        "--cleanup-local",
+        help="Delete the local task copy once it is published to the dataset repo "
+        "(frees disk on constrained sandboxes; never deletes an unpublished task)",
+    ),
 ) -> None:
     """
     Continuously process merged GitHub PRs and convert them to Harbor tasks.
@@ -588,6 +603,7 @@ def farm(
             publish_state_path,
             publish_clone_dir,
             publish_dry_run,
+            publish_cleanup_local,
         ),
     )
 

--- a/src/swegen/cli.py
+++ b/src/swegen/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from importlib.metadata import PackageNotFoundError as _PkgNotFound
 from importlib.metadata import version as _pkg_version
 from pathlib import Path
@@ -9,18 +10,63 @@ from dotenv import load_dotenv
 from harbor.models.environment_type import EnvironmentType
 from rich.console import Console
 
-from swegen.config import CreateConfig, FarmConfig
+from swegen.config import CreateConfig, FarmConfig, PublishConfig
 from swegen.create import MissingIssueError, TrivialPRError
 from swegen.create.create import run_reversal
 from swegen.farm import StreamFarmer
 from swegen.analyze import AnalyzeArgs, run_analyze
 from swegen.analyze.classifier import VERDICT_MODEL
+from swegen.publish import PublishError
 from swegen.tools.validate import ValidateArgs, run_validate
 from swegen.tools.validate_utils import ValidationError
 
 load_dotenv()
 
 app = typer.Typer(no_args_is_help=True, add_completion=False, help="Task generation CLI")
+
+DEFAULT_AUTHOR_NAME = "aman-abundant"
+DEFAULT_AUTHOR_EMAIL = "aman@abundant.systems"
+
+
+def _build_publish_config(
+    publish_repo: str | None,
+    publish_path: str,
+    publish_base: str,
+    publish_branch_prefix: str,
+    publish_state_branch_prefix: str,
+    publish_state_path: str,
+    publish_clone_dir: Path | None,
+    publish_dry_run: bool,
+) -> PublishConfig | None:
+    """Build a PublishConfig from CLI options, or None when publishing is off.
+
+    Publishing is enabled by the presence of --publish-repo. The token comes from
+    GIT_TOKEN, falling back to GITHUB_TOKEN, and is deliberately separate from the
+    read-only token used to fetch source PRs.
+    """
+    if not publish_repo:
+        return None
+
+    token = os.environ.get("GIT_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise typer.BadParameter(
+            "--publish-repo requires GIT_TOKEN (or GITHUB_TOKEN) in the environment. "
+            "It needs contents:write and pull_requests:write on the dataset repo."
+        )
+
+    return PublishConfig(
+        repo=publish_repo,
+        token=token,
+        tasks_path=publish_path,
+        base_branch=publish_base,
+        branch_prefix=publish_branch_prefix,
+        state_branch_prefix=publish_state_branch_prefix,
+        state_path=publish_state_path,
+        clone_dir=publish_clone_dir,
+        dry_run=publish_dry_run,
+        author_name=os.environ.get("GIT_AUTHOR_NAME", DEFAULT_AUTHOR_NAME),
+        author_email=os.environ.get("GIT_AUTHOR_EMAIL", DEFAULT_AUTHOR_EMAIL),
+    )
 
 
 @app.callback(invoke_without_command=True)
@@ -106,6 +152,43 @@ def create_cmd(
         help="Environment type for Harbor runs (docker|daytona|e2b|modal|runloop|gke)",
         show_default=True,
     ),
+    publish_repo: str
+    | None = typer.Option(
+        None,
+        "--publish-repo",
+        help="Dataset repo (owner/repo) to publish the task to as a PR. Requires GIT_TOKEN. "
+        "Omit to keep tasks local.",
+    ),
+    publish_path: str = typer.Option(
+        "tasks", "--publish-path", help="Directory within the dataset repo", show_default=True
+    ),
+    publish_base: str = typer.Option(
+        "main", "--publish-base", help="Branch task branches are cut from", show_default=True
+    ),
+    publish_branch_prefix: str = typer.Option(
+        "task/", "--publish-branch-prefix", help="Prefix for per-task branches", show_default=True
+    ),
+    publish_state_branch_prefix: str = typer.Option(
+        "farm-state/",
+        "--publish-state-branch-prefix",
+        help="Prefix for the per-source-repo state branch",
+        show_default=True,
+    ),
+    publish_state_path: str = typer.Option(
+        "state", "--publish-state-path", help="Directory on the state branch", show_default=True
+    ),
+    publish_clone_dir: Path
+    | None = typer.Option(
+        None,
+        "--publish-clone-dir",
+        help="Where to clone the dataset repo "
+        "(default: <state-dir>/publish/<dataset_slug>/<source_slug>)",
+    ),
+    publish_dry_run: bool = typer.Option(
+        False,
+        "--publish-dry-run",
+        help="Clone, branch and commit locally but never push or open a PR",
+    ),
     verbose: bool = typer.Option(False, "-v", "--verbose", help="Increase output verbosity"),
     quiet: bool = typer.Option(False, "-q", "--quiet", help="Reduce output verbosity"),
 ) -> None:
@@ -126,12 +209,28 @@ def create_cmd(
         environment=EnvironmentType(environment),
         generate_name=generate_name,
         enforce_offline_tests=enforce_offline_tests,
+        publish=_build_publish_config(
+            publish_repo,
+            publish_path,
+            publish_base,
+            publish_branch_prefix,
+            publish_state_branch_prefix,
+            publish_state_path,
+            publish_clone_dir,
+            publish_dry_run,
+        ),
         verbose=verbose,
         quiet=quiet,
     )
     try:
         run_reversal(config)
-    except (TrivialPRError, MissingIssueError, ValidationError, FileExistsError) as err:
+    except (
+        TrivialPRError,
+        MissingIssueError,
+        ValidationError,
+        FileExistsError,
+        PublishError,
+    ) as err:
         # These exceptions have already displayed user-friendly messages
         # Exit with error code but don't show traceback
         raise SystemExit(1) from err
@@ -410,11 +509,52 @@ def farm(
         "[environment].network_mode=no-network in task.toml (internet only during Docker build); "
         "--allow-test-network to disable",
     ),
+    publish_repo: str
+    | None = typer.Option(
+        None,
+        "--publish-repo",
+        help="Dataset repo (owner/repo) to publish each task to as a PR, and to persist farm "
+        "state to. Requires GIT_TOKEN. Omit to keep tasks and state local.",
+    ),
+    publish_path: str = typer.Option(
+        "tasks", "--publish-path", help="Directory within the dataset repo", show_default=True
+    ),
+    publish_base: str = typer.Option(
+        "main", "--publish-base", help="Branch task branches are cut from", show_default=True
+    ),
+    publish_branch_prefix: str = typer.Option(
+        "task/", "--publish-branch-prefix", help="Prefix for per-task branches", show_default=True
+    ),
+    publish_state_branch_prefix: str = typer.Option(
+        "farm-state/",
+        "--publish-state-branch-prefix",
+        help="Prefix for the per-source-repo state branch",
+        show_default=True,
+    ),
+    publish_state_path: str = typer.Option(
+        "state", "--publish-state-path", help="Directory on the state branch", show_default=True
+    ),
+    publish_clone_dir: Path
+    | None = typer.Option(
+        None,
+        "--publish-clone-dir",
+        help="Where to clone the dataset repo "
+        "(default: <state-dir>/publish/<dataset_slug>/<source_slug>)",
+    ),
+    publish_dry_run: bool = typer.Option(
+        False,
+        "--publish-dry-run",
+        help="Clone, branch and commit locally but never push or open a PR",
+    ),
 ) -> None:
     """
     Continuously process merged GitHub PRs and convert them to Harbor tasks.
     Streams PRs page-by-page, processes them immediately, and maintains state for resumable operation.
     Uses a language-agnostic pipeline that works for any repository.
+
+    With --publish-repo, each validated task is pushed to its own branch and opened as a
+    PR immediately, and farm state is committed to a per-repo state branch - so an
+    ephemeral sandbox (e.g. Daytona) can die without losing tasks or the resume cursor.
     """
     config = FarmConfig(
         repo=repo,
@@ -439,9 +579,25 @@ def farm(
         require_issue=require_issue,
         validate=validate,
         enforce_offline_tests=enforce_offline_tests,
+        publish=_build_publish_config(
+            publish_repo,
+            publish_path,
+            publish_base,
+            publish_branch_prefix,
+            publish_state_branch_prefix,
+            publish_state_path,
+            publish_clone_dir,
+            publish_dry_run,
+        ),
     )
 
     console = Console()
-    farmer = StreamFarmer(config.repo, config, console)
+    try:
+        # Preflights the publish target, so a bad token fails here rather than after the
+        # first hour-long Claude Code session.
+        farmer = StreamFarmer(config.repo, config, console)
+    except PublishError as err:
+        console.print(f"[red]Cannot start farming: {err}[/red]")
+        raise SystemExit(1) from err
     exit_code = farmer.run()
     raise typer.Exit(code=exit_code)

--- a/src/swegen/cli.py
+++ b/src/swegen/cli.py
@@ -371,6 +371,11 @@ def farm(
     docker_prune_batch: int = typer.Option(
         5, help="Run docker cleanup after every N PRs (0 to disable)", show_default=True
     ),
+    build_cache_keep: str = typer.Option(
+        "20GB",
+        help="Docker build cache to retain during cleanup (keeps base/runtime layers warm)",
+        show_default=True,
+    ),
     skip_list: str
     | None = typer.Option(None, help="Path to file with task IDs to skip (one per line)"),
     no_cache: bool = typer.Option(
@@ -425,6 +430,7 @@ def farm(
         cc_timeout=cc_timeout,
         api_delay=api_delay,
         task_delay=task_delay,
+        build_cache_keep=build_cache_keep,
         reset=reset,
         resume_from=resume_from,
         dry_run=dry_run,

--- a/src/swegen/config.py
+++ b/src/swegen/config.py
@@ -30,6 +30,10 @@ class PublishConfig:
             .swegen/publish/<dataset_slug>/<source_slug>, keyed by source repo so two
             farms sharing a host never fight over one working tree.
         dry_run: Perform local clone/branch/commit but skip pushes and PR creation
+        cleanup_local: Delete the local task directory once the task is durably published
+            (a real PR/branch on the dataset repo). Frees disk on resource-constrained
+            sandboxes. Never deletes on dry-run, on publish failure, or when the task was
+            not actually published - the dataset repo must hold the only surviving copy.
         author_name: git author/committer name for task and state commits
         author_email: git author/committer email for task and state commits
     """
@@ -43,6 +47,7 @@ class PublishConfig:
     state_path: str = "state"
     clone_dir: Path | None = None
     dry_run: bool = False
+    cleanup_local: bool = False
     author_name: str = "aman-abundant"
     author_email: str = "aman@abundant.systems"
 

--- a/src/swegen/config.py
+++ b/src/swegen/config.py
@@ -8,6 +8,46 @@ from harbor.models.environment_type import EnvironmentType
 
 
 @dataclass(frozen=True)
+class PublishConfig:
+    """Configuration for publishing generated tasks to a dataset repository.
+
+    When present on a CreateConfig/FarmConfig, every validated task is copied into
+    a clone of ``repo``, committed on its own branch cut fresh from ``base_branch``,
+    pushed, and opened as a pull request. Farm state is committed to a separate,
+    per-source-repo branch so an ephemeral sandbox can resume where it left off.
+
+    Attributes:
+        repo: Dataset repository in "owner/repo" format (receives the task PRs)
+        token: Token with contents:write + pull_requests:write on ``repo``
+        tasks_path: Directory within ``repo`` that tasks are written to
+        base_branch: Branch every task branch is cut from, and that PRs target
+        branch_prefix: Prefix for per-task branches ("task/" -> "task/<task_id>")
+        state_branch_prefix: Prefix for the per-source-repo state branch. Git refs are a
+            directory namespace, so a bare "farm-state" branch cannot coexist with
+            "farm-state/<slug>" - only the prefixed form is ever created.
+        state_path: Directory within the state branch holding state JSON
+        clone_dir: Where to clone the dataset repo. Defaults to
+            .swegen/publish/<dataset_slug>/<source_slug>, keyed by source repo so two
+            farms sharing a host never fight over one working tree.
+        dry_run: Perform local clone/branch/commit but skip pushes and PR creation
+        author_name: git author/committer name for task and state commits
+        author_email: git author/committer email for task and state commits
+    """
+
+    repo: str
+    token: str
+    tasks_path: str = "tasks"
+    base_branch: str = "main"
+    branch_prefix: str = "task/"
+    state_branch_prefix: str = "farm-state/"
+    state_path: str = "state"
+    clone_dir: Path | None = None
+    dry_run: bool = False
+    author_name: str = "aman-abundant"
+    author_email: str = "aman@abundant.systems"
+
+
+@dataclass(frozen=True)
 class CreateConfig:
     """Configuration for the create command (PR → Harbor task).
 
@@ -35,6 +75,7 @@ class CreateConfig:
             When True (default): CC is told not to install/network in test.sh, a static gate hard-fails
             any test.sh that does, and the generated task.toml sets [environment].network_mode=no-network
             (internet is available only during the Docker build). Disable with --allow-test-network.
+        publish: When set, publish the validated task as a PR on a dataset repo
         verbose: Increase output verbosity
         quiet: Reduce output verbosity
     """
@@ -55,6 +96,7 @@ class CreateConfig:
     environment: EnvironmentType = EnvironmentType.DOCKER
     generate_name: bool = False
     enforce_offline_tests: bool = True
+    publish: PublishConfig | None = None
     verbose: bool = False
     quiet: bool = False
 
@@ -97,6 +139,8 @@ class FarmConfig:
         validate: Run Harbor validation after CC (useful when CC times out but task may be valid)
         enforce_offline_tests: Forbid runtime dependency installs / network access in tests/test.sh
             (see CreateConfig). Disable with --allow-test-network.
+        publish: When set, publish each validated task as a PR on a dataset repo and
+            persist farm state to a branch on that repo (survives ephemeral sandboxes).
     """
 
     repo: str
@@ -121,6 +165,7 @@ class FarmConfig:
     require_issue: bool = True
     validate: bool = True
     enforce_offline_tests: bool = True
+    publish: PublishConfig | None = None
 
 
 @dataclass(frozen=True)

--- a/src/swegen/config.py
+++ b/src/swegen/config.py
@@ -86,6 +86,10 @@ class FarmConfig:
         resume_from: Resume from date (ISO format or YYYY-MM-DD)
         dry_run: Only show what would run (no task generation)
         docker_prune_batch: Run docker cleanup after every N PRs (0 to disable)
+        build_cache_keep: Ceiling for the retained Docker build cache during cleanup
+            (any docker size string, e.g. "20GB"). Layers above this are evicted
+            least-recently-used first, so the base/runtime layers shared by every task
+            survive while per-task layers are reclaimed.
         skip_list: Path to file with task IDs to skip
         no_cache: Disable reusing cached Dockerfiles/test.sh
         require_minimum_difficulty: Require 3+ source files for task
@@ -111,6 +115,7 @@ class FarmConfig:
     resume_from: str | None = None
     dry_run: bool = False
     docker_prune_batch: int = 5
+    build_cache_keep: str = "20GB"
     skip_list: str | None = None
     no_cache: bool = False
     require_minimum_difficulty: bool = True

--- a/src/swegen/create/claude_code_runner.py
+++ b/src/swegen/create/claude_code_runner.py
@@ -18,6 +18,31 @@ from swegen.create.claude_code_utils import Colors, print_sdk_message
 from swegen.tools.harbor_runner import parse_harbor_outcome
 
 
+class ClaudeRateLimitError(RuntimeError):
+    """Claude Code hit an Anthropic rate / usage limit.
+
+    Fatal for farming: every subsequent task draws from the same limit and fails the same
+    way until the token/account is swapped, so there is no point spending a Claude Code
+    session per PR. The farm stops instead. The task's source PR is left unprocessed so it
+    is farmed on a re-run with a fresh token.
+    """
+
+
+# Substrings (lowercased) that mark a Claude Code failure as a rate/usage limit rather than
+# a task-specific problem. `rate_limit_event` is the SDK message-parse crash observed in the
+# field (claude-agent-sdk does not handle that stream event); the others cover a 429 or usage
+# cap surfaced through the SDK.
+_RATE_LIMIT_MARKERS = ("rate_limit_event", "rate limit", "rate_limited", "usage limit")
+
+
+def is_rate_limit_failure(error_message: str | None) -> bool:
+    """True if a Claude Code error message indicates an Anthropic rate/usage limit."""
+    if not error_message:
+        return False
+    lowered = error_message.lower()
+    return any(marker in lowered for marker in _RATE_LIMIT_MARKERS)
+
+
 @dataclass
 class ClaudeCodeResult:
     """Result of the CC session."""

--- a/src/swegen/create/create.py
+++ b/src/swegen/create/create.py
@@ -290,6 +290,22 @@ def _save_state_record(
         logger.warning(f"Unexpected error saving state record for {repo_key}: {e}", exc_info=True)
 
 
+def _cleanup_local_task(console: Console, task_dir: Path) -> None:
+    """Delete the local task directory after it has been durably published.
+
+    Caller must have confirmed the task reached the dataset repo. Non-fatal: a failed
+    delete only wastes disk, so it is logged, not raised.
+    """
+    import shutil
+
+    try:
+        if task_dir.exists():
+            shutil.rmtree(task_dir)
+            console.print(f"[dim]Removed local task copy {task_dir} (published)[/dim]")
+    except OSError as e:
+        console.print(f"[yellow]Could not remove local task copy {task_dir}: {e}[/yellow]")
+
+
 def _preflight_publish(console: Console, config: CreateConfig, repo: str) -> TaskSink:
     """Build the sink and verify the dataset repo is writable, before any work begins.
 
@@ -567,9 +583,7 @@ def run_reversal(config: CreateConfig) -> str | None:
                 # whose push failed records published=False). Publish it rather than
                 # returning as if the work were done, and never regenerate - that would
                 # delete a valid task.
-                result = publish_existing_task(
-                    console, config, pipeline.repo, config.pr, duplicate
-                )
+                result = publish_existing_task(console, config, pipeline.repo, config.pr, duplicate)
                 # Supersede the unpublished record once the republish actually reaches the
                 # dataset repo. Key on `published`, not the URL: a task already merged into
                 # the base branch republishes with published=True and no URL, and keying on
@@ -848,6 +862,11 @@ def run_reversal(config: CreateConfig) -> str | None:
         pr_url = publish_result.pr_url if publish_result else None
         published = publish_result.published if publish_result else True
 
+        # Whether the task actually reached the dataset repo (a real branch/PR, or already
+        # merged into base). Distinct from `published` above, which is True even when
+        # publishing is disabled - keying cleanup on that would delete the only copy.
+        did_publish = publish_result is not None and publish_result.published
+
         # Save state record (non-fatal if fails)
         _save_state_record(
             state_dir,
@@ -862,7 +881,13 @@ def run_reversal(config: CreateConfig) -> str | None:
 
         # Display final panels
         _display_summary_panel(
-            console, pipeline.repo, config.pr, task_id, task_dir, gen_log_path, validation_table,
+            console,
+            pipeline.repo,
+            config.pr,
+            task_id,
+            task_dir,
+            gen_log_path,
+            validation_table,
             linked_issues=linked_issues,
         )
         _display_logs_panel(
@@ -872,6 +897,14 @@ def run_reversal(config: CreateConfig) -> str | None:
             harbor_oracle_job_dir,
         )
         _display_next_steps_panel(console, harbor_root, task_id)
+
+        # Cleanup is the LAST step: everything above (summary panel, state record) reads the
+        # task dir. Only ever deletes a task that reached the dataset repo, so the remote is
+        # the surviving copy. The farm suppresses this (passes cleanup_local=False) and does
+        # its own cleanup after saving a task reference.
+        if config.publish is not None and config.publish.cleanup_local and did_publish:
+            _cleanup_local_task(console, task_dir)
+
         return pr_url
     except PublishError as e:
         # Already-diagnosed publish failure: show the reason, skip the traceback.

--- a/src/swegen/create/create.py
+++ b/src/swegen/create/create.py
@@ -17,6 +17,7 @@ from rich.text import Text
 from rich.traceback import install as rich_traceback_install
 
 from swegen.config import CreateConfig
+from swegen.publish import PublishContext, PublishError, build_task_sink
 from swegen.tools.harbor_runner import parse_harbor_outcome, run_harbor_agent
 from swegen.tools.policy import find_test_network_violations, format_violations
 from swegen.tools.validate_utils import ValidationError, run_nop_oracle
@@ -281,6 +282,45 @@ def _save_state_record(
         logger.warning(f"Unexpected error saving state record for {repo_key}: {e}", exc_info=True)
 
 
+def _publish_task(
+    console: Console,
+    config: CreateConfig,
+    repo: str,
+    pr: int,
+    task_id: str,
+    task_dir: Path,
+    metadata: dict,
+) -> str | None:
+    """Publish the validated task as a PR on the dataset repo.
+
+    Runs only after every gate has passed, so the dataset repo never receives a task
+    that failed validation. Raises PublishError on failure - an unpublished task is
+    lost when an ephemeral sandbox dies, so it is not a success.
+
+    Returns the PR URL, or None when publishing is disabled or dry-run.
+    """
+    sink = build_task_sink(config.publish, repo, state_dir=config.state_dir)
+    ctx = PublishContext(
+        task_id=task_id,
+        task_dir=task_dir,
+        source_repo=repo,
+        source_pr=pr,
+        source_pr_url=metadata.get("html_url", f"https://github.com/{repo}/pull/{pr}"),
+        metadata=metadata,
+    )
+
+    if config.publish is None:
+        return None
+
+    console.print(Rule(Text("Publish", style="bold blue")))
+    result = sink.publish(ctx)
+    if result.pr_url:
+        console.print(f"[green]✓ Published {task_id} → {result.pr_url}[/green]")
+    elif config.publish.dry_run:
+        console.print(f"[cyan]DRY RUN: would publish {task_id} on branch {result.branch}[/cyan]")
+    return result.pr_url
+
+
 def _display_summary_panel(
     console: Console,
     repo: str,
@@ -410,11 +450,15 @@ def _run_harbor_validations(
     return results_rows, job_dirs
 
 
-def run_reversal(config: CreateConfig) -> None:
+def run_reversal(config: CreateConfig) -> str | None:
     """Convert a merged PR into a Harbor task.
 
     Args:
         config: Typed configuration with repo, PR number, and options.
+
+    Returns:
+        URL of the pull request the task was published to, or None if publishing is
+        disabled (no config.publish), running dry, or the task was skipped by dedupe.
     """
     rich_traceback_install(show_locals=False)
     console = Console()
@@ -669,6 +713,12 @@ def run_reversal(config: CreateConfig) -> None:
             state_dir, state_file, repo_key, pipeline.repo, config.pr, task_id, task_dir
         )
 
+        # Publish the task before anything else can go wrong. On ephemeral sandboxes
+        # this is the only durable copy of the task.
+        pr_url = _publish_task(
+            console, config, pipeline.repo, config.pr, task_id, task_dir, metadata
+        )
+
         # Display final panels
         _display_summary_panel(
             console, pipeline.repo, config.pr, task_id, task_dir, gen_log_path, validation_table,
@@ -681,6 +731,13 @@ def run_reversal(config: CreateConfig) -> None:
             harbor_oracle_job_dir,
         )
         _display_next_steps_panel(console, harbor_root, task_id)
+        return pr_url
+    except PublishError as e:
+        # Already-diagnosed publish failure: show the reason, skip the traceback.
+        console.print(
+            Panel(Text(str(e), style="red"), title="[red]Publish Failed[/red]", border_style="red")
+        )
+        raise
     except (TrivialPRError, MissingIssueError, ValidationError, FileExistsError):
         # Re-raise these exceptions so caller can handle them
         raise

--- a/src/swegen/create/create.py
+++ b/src/swegen/create/create.py
@@ -258,8 +258,13 @@ def _save_state_record(
     pr: int,
     task_id: str,
     task_dir: Path,
+    published: bool = True,
 ) -> None:
     """Save a record of the generated task to the state file.
+
+    Written even when publishing failed (`published=False`), so a rerun's dedupe check
+    finds the task and republishes it instead of hitting FileExistsError and needing
+    --force, which would delete the validated task.
 
     This is non-fatal - errors are logged but do not stop execution.
     """
@@ -273,6 +278,7 @@ def _save_state_record(
             "task_id": task_id,
             "harbor": str(task_dir.resolve()),
             "ts": datetime.now(UTC).isoformat(),
+            "published": published,
         }
         with open(state_file, "a") as f:
             f.write(json.dumps(rec) + "\n")
@@ -537,9 +543,23 @@ def run_reversal(config: CreateConfig) -> str | None:
         state_file = state_dir / "create.jsonl"
         duplicate = _check_dedupe(console, repo_key, state_file, config.force)
         if duplicate is not None:
-            # The task exists on disk but may never have been published. Publish it rather
-            # than returning as if the work were done.
-            return publish_existing_task(console, config, pipeline.repo, config.pr, duplicate)
+            # The task exists on disk but may never have been published (a prior run whose
+            # push failed records published=False). Publish it rather than returning as if
+            # the work were done, and never regenerate - that would delete a valid task.
+            pr_url = publish_existing_task(console, config, pipeline.repo, config.pr, duplicate)
+            if pr_url and not duplicate.get("published", True):
+                # Recovered: supersede the unpublished record so later runs see it as done.
+                _save_state_record(
+                    state_dir,
+                    state_file,
+                    repo_key,
+                    pipeline.repo,
+                    config.pr,
+                    duplicate.get("task_id") or Path(duplicate["harbor"]).name,
+                    Path(duplicate["harbor"]),
+                    published=True,
+                )
+            return pr_url
 
         # Verify the dataset repo is writable before spending a Claude Code session on a
         # task we would then be unable to publish.
@@ -770,12 +790,29 @@ def run_reversal(config: CreateConfig) -> str | None:
             console, harbor_validation_failed, cc_validation_failed, harbor_actually_ran
         )
 
-        # Publish before recording the dedupe entry. A task written to create.jsonl but
-        # never published would be skipped by the next run's dedupe check, leaving no way
-        # to retry the publish without --force.
-        pr_url = _publish_task(
-            console, config, sink, pipeline.repo, config.pr, task_id, task_dir, metadata
-        )
+        # Publish before recording the dedupe entry, so a task that never reached the
+        # dataset repo is not recorded as fully done.
+        try:
+            pr_url = _publish_task(
+                console, config, sink, pipeline.repo, config.pr, task_id, task_dir, metadata
+            )
+        except PublishError:
+            # Still record the task, flagged unpublished. The task is valid - only the push
+            # failed - and without a record a rerun would hit FileExistsError on the task
+            # directory and need --force, which deletes it. With the record, dedupe finds
+            # the task and republishes it (publish_existing_task), matching the farm's
+            # publish-only retry.
+            _save_state_record(
+                state_dir,
+                state_file,
+                repo_key,
+                pipeline.repo,
+                config.pr,
+                task_id,
+                task_dir,
+                published=False,
+            )
+            raise
 
         # Save state record (non-fatal if fails)
         _save_state_record(

--- a/src/swegen/create/create.py
+++ b/src/swegen/create/create.py
@@ -329,11 +329,13 @@ def publish_existing_task(
     task_dir = Path(record.get("harbor", ""))
     task_id = record.get("task_id") or task_dir.name
     if not task_dir.exists():
-        console.print(
-            f"[yellow]Task {task_id} is recorded in state but missing from disk "
-            f"({task_dir}); nothing to publish. Use --force to regenerate.[/yellow]"
+        # Never return None here: the caller would read that as "published, nothing to do"
+        # and exit successfully having published nothing. Callers that can recover check
+        # the directory first and regenerate instead.
+        raise PublishError(
+            f"Task {task_id} is recorded in state but missing from disk ({task_dir}); "
+            f"nothing to publish."
         )
-        return None
 
     console.print(f"[cyan]Task already generated; publishing {task_id} from {task_dir}[/cyan]")
     sink = _preflight_publish(console, config, repo)
@@ -543,23 +545,36 @@ def run_reversal(config: CreateConfig) -> str | None:
         state_file = state_dir / "create.jsonl"
         duplicate = _check_dedupe(console, repo_key, state_file, config.force)
         if duplicate is not None:
-            # The task exists on disk but may never have been published (a prior run whose
-            # push failed records published=False). Publish it rather than returning as if
-            # the work were done, and never regenerate - that would delete a valid task.
-            pr_url = publish_existing_task(console, config, pipeline.repo, config.pr, duplicate)
-            if pr_url and not duplicate.get("published", True):
-                # Recovered: supersede the unpublished record so later runs see it as done.
-                _save_state_record(
-                    state_dir,
-                    state_file,
-                    repo_key,
-                    pipeline.repo,
-                    config.pr,
-                    duplicate.get("task_id") or Path(duplicate["harbor"]).name,
-                    Path(duplicate["harbor"]),
-                    published=True,
+            duplicate_dir = Path(duplicate.get("harbor", ""))
+            if not duplicate_dir.exists():
+                # Stale record: the task it names is gone, so there is nothing to publish
+                # and nothing to protect. Fall through and regenerate rather than exiting
+                # successfully having done nothing.
+                console.print(
+                    f"[yellow]Recorded task is missing from disk ({duplicate_dir}); "
+                    f"regenerating.[/yellow]"
                 )
-            return pr_url
+            else:
+                # The task exists on disk but may never have been published (a prior run
+                # whose push failed records published=False). Publish it rather than
+                # returning as if the work were done, and never regenerate - that would
+                # delete a valid task.
+                pr_url = publish_existing_task(
+                    console, config, pipeline.repo, config.pr, duplicate
+                )
+                if pr_url and not duplicate.get("published", True):
+                    # Recovered: supersede the unpublished record so later runs see it done.
+                    _save_state_record(
+                        state_dir,
+                        state_file,
+                        repo_key,
+                        pipeline.repo,
+                        config.pr,
+                        duplicate.get("task_id") or duplicate_dir.name,
+                        duplicate_dir,
+                        published=True,
+                    )
+                return pr_url
 
         # Verify the dataset repo is writable before spending a Claude Code session on a
         # task we would then be unable to publish.

--- a/src/swegen/create/create.py
+++ b/src/swegen/create/create.py
@@ -299,20 +299,23 @@ def _preflight_publish(console: Console, config: CreateConfig, repo: str) -> Tas
     return sink
 
 
-def _publish_existing_task(
+def publish_existing_task(
     console: Console,
     config: CreateConfig,
     repo: str,
     pr: int,
     record: dict,
 ) -> str | None:
-    """Publish a task that dedupe says was already generated.
+    """Publish a task that already exists on disk, without regenerating it.
 
-    A dedupe hit means the task exists on disk, NOT that it reached the dataset repo -
-    it may have been generated before publishing was configured, or by a run whose push
-    failed. Returning silently would let the farm mark the source PR processed with no PR
-    ever opened. Publishing is idempotent, so re-publishing an already-published task
-    returns its existing PR URL.
+    Used for two recoveries:
+      * a dedupe hit - the task exists but may never have reached the dataset repo
+      * a publish-only retry after a failed push, where regenerating would destroy the
+        validated task the farm deliberately preserved
+
+    Returning silently would let the farm mark the source PR processed with no PR ever
+    opened. Publishing is idempotent, so re-publishing an already-published task returns
+    its existing PR URL.
     """
     if config.publish is None:
         return None
@@ -536,7 +539,7 @@ def run_reversal(config: CreateConfig) -> str | None:
         if duplicate is not None:
             # The task exists on disk but may never have been published. Publish it rather
             # than returning as if the work were done.
-            return _publish_existing_task(console, config, pipeline.repo, config.pr, duplicate)
+            return publish_existing_task(console, config, pipeline.repo, config.pr, duplicate)
 
         # Verify the dataset repo is writable before spending a Claude Code session on a
         # task we would then be unable to publish.

--- a/src/swegen/create/create.py
+++ b/src/swegen/create/create.py
@@ -311,7 +311,7 @@ def publish_existing_task(
     repo: str,
     pr: int,
     record: dict,
-) -> str | None:
+) -> PublishResult | None:
     """Publish a task that already exists on disk, without regenerating it.
 
     Used for two recoveries:
@@ -319,9 +319,10 @@ def publish_existing_task(
       * a publish-only retry after a failed push, where regenerating would destroy the
         validated task the farm deliberately preserved
 
-    Returning silently would let the farm mark the source PR processed with no PR ever
-    opened. Publishing is idempotent, so re-publishing an already-published task returns
-    its existing PR URL.
+    Returns the full PublishResult, not just the URL: a successful republish of a task
+    already merged into the base branch has published=True but no URL, and the caller must
+    key "did this reach the dataset repo?" on `published`, not on the URL. None only when
+    publishing is disabled.
     """
     if config.publish is None:
         return None
@@ -339,8 +340,7 @@ def publish_existing_task(
 
     console.print(f"[cyan]Task already generated; publishing {task_id} from {task_dir}[/cyan]")
     sink = _preflight_publish(console, config, repo)
-    result = _publish_task(console, config, sink, repo, pr, task_id, task_dir, metadata={})
-    return result.pr_url if result else None
+    return _publish_task(console, config, sink, repo, pr, task_id, task_dir, metadata={})
 
 
 def _publish_task(
@@ -567,11 +567,15 @@ def run_reversal(config: CreateConfig) -> str | None:
                 # whose push failed records published=False). Publish it rather than
                 # returning as if the work were done, and never regenerate - that would
                 # delete a valid task.
-                pr_url = publish_existing_task(
+                result = publish_existing_task(
                     console, config, pipeline.repo, config.pr, duplicate
                 )
-                if pr_url and not duplicate.get("published", True):
-                    # Recovered: supersede the unpublished record so later runs see it done.
+                # Supersede the unpublished record once the republish actually reaches the
+                # dataset repo. Key on `published`, not the URL: a task already merged into
+                # the base branch republishes with published=True and no URL, and keying on
+                # the URL would leave published=False forever and republish on every run.
+                published = result.published if result else False
+                if published and not duplicate.get("published", True):
                     _save_state_record(
                         state_dir,
                         state_file,
@@ -582,7 +586,7 @@ def run_reversal(config: CreateConfig) -> str | None:
                         duplicate_dir,
                         published=True,
                     )
-                return pr_url
+                return result.pr_url if result else None
 
         # Verify the dataset repo is writable before spending a Claude Code session on a
         # task we would then be unable to publish.

--- a/src/swegen/create/create.py
+++ b/src/swegen/create/create.py
@@ -90,13 +90,15 @@ def _check_dedupe(
     repo_key: str,
     state_file: Path,
     force: bool,
-) -> bool:
+) -> dict | None:
     """Check if task already exists in state file.
 
-    Returns True if duplicate found and should skip, False otherwise.
+    Returns the recorded state entry if a duplicate is found, else None. The caller needs
+    the record - not just a bool - because a previously generated task may still be
+    unpublished, and its recorded directory is where the task lives.
     """
     if force or not state_file.exists():
-        return False
+        return None
 
     last_rec = None
     logger = logging.getLogger("swegen")
@@ -122,8 +124,8 @@ def _check_dedupe(
                 border_style="yellow",
             )
         )
-        return True
-    return False
+        return last_rec
+    return None
 
 
 def _display_validation_results(
@@ -295,6 +297,38 @@ def _preflight_publish(console: Console, config: CreateConfig, repo: str) -> Tas
         )
         sink.preflight()
     return sink
+
+
+def _publish_existing_task(
+    console: Console,
+    config: CreateConfig,
+    repo: str,
+    pr: int,
+    record: dict,
+) -> str | None:
+    """Publish a task that dedupe says was already generated.
+
+    A dedupe hit means the task exists on disk, NOT that it reached the dataset repo -
+    it may have been generated before publishing was configured, or by a run whose push
+    failed. Returning silently would let the farm mark the source PR processed with no PR
+    ever opened. Publishing is idempotent, so re-publishing an already-published task
+    returns its existing PR URL.
+    """
+    if config.publish is None:
+        return None
+
+    task_dir = Path(record.get("harbor", ""))
+    task_id = record.get("task_id") or task_dir.name
+    if not task_dir.exists():
+        console.print(
+            f"[yellow]Task {task_id} is recorded in state but missing from disk "
+            f"({task_dir}); nothing to publish. Use --force to regenerate.[/yellow]"
+        )
+        return None
+
+    console.print(f"[cyan]Task already generated; publishing {task_id} from {task_dir}[/cyan]")
+    sink = _preflight_publish(console, config, repo)
+    return _publish_task(console, config, sink, repo, pr, task_id, task_dir, metadata={})
 
 
 def _publish_task(
@@ -498,8 +532,11 @@ def run_reversal(config: CreateConfig) -> str | None:
         repo_key = f"{pipeline.repo.lower()}#{config.pr}"
         state_dir: Path = config.state_dir or Path(".swegen")
         state_file = state_dir / "create.jsonl"
-        if _check_dedupe(console, repo_key, state_file, config.force):
-            return
+        duplicate = _check_dedupe(console, repo_key, state_file, config.force)
+        if duplicate is not None:
+            # The task exists on disk but may never have been published. Publish it rather
+            # than returning as if the work were done.
+            return _publish_existing_task(console, config, pipeline.repo, config.pr, duplicate)
 
         # Verify the dataset repo is writable before spending a Claude Code session on a
         # task we would then be unable to publish.

--- a/src/swegen/create/create.py
+++ b/src/swegen/create/create.py
@@ -30,6 +30,7 @@ from .claude_code_runner import (
     run_claude_code_session,
 )
 from .repo_cache import RepoCache
+from .task_reference import TaskReferenceStore
 
 # -----------------------------------------------------------------------------
 # Helper functions for run_reversal phases
@@ -293,6 +294,31 @@ def _save_state_record(
     except Exception as e:
         # Catch-all for unexpected errors, but still log them
         logger.warning(f"Unexpected error saving state record for {repo_key}: {e}", exc_info=True)
+
+
+def _save_task_reference(
+    console: Console,
+    config: CreateConfig,
+    repo: str,
+    task_id: str,
+    pr: int,
+    task_dir: Path,
+) -> None:
+    """Record this validated task as the repo's reference for faster future generation.
+
+    Skipped under --cleanup-local: the task directory is deleted after publishing, and a
+    reference tells Claude Code to read that directory - a dangling pointer helps nobody.
+    Non-fatal: a reference is only a speed-up, so a failure is warned, not raised.
+    """
+    if config.publish is not None and config.publish.cleanup_local:
+        return
+    try:
+        reference_file = Path(config.state_dir) / "task_references.json"
+        TaskReferenceStore(reference_file=reference_file).save(
+            repo=repo, task_id=task_id, pr_number=pr
+        )
+    except Exception as e:
+        console.print(f"[yellow]Warning: Could not save task reference: {e}[/yellow]")
 
 
 def _cleanup_local_task(console: Console, task_dir: Path) -> None:
@@ -842,6 +868,11 @@ def run_reversal(config: CreateConfig) -> str | None:
         _handle_validation_failure(
             console, harbor_validation_failed, cc_validation_failed, harbor_actually_ran
         )
+
+        # Save the task reference now: the task is validated, and this is BEFORE publish, so
+        # a task that then fails to publish (or is republished on retry, which never calls
+        # run_reversal) still records its reference for faster future generation.
+        _save_task_reference(console, config, pipeline.repo, task_id, config.pr, task_dir)
 
         # Publish before recording the dedupe entry, so a task that never reached the
         # dataset repo is not recorded as fully done.

--- a/src/swegen/create/create.py
+++ b/src/swegen/create/create.py
@@ -120,7 +120,7 @@ def _check_dedupe(
             Panel(
                 body,
                 title=f"Duplicate key: [bold]{repo_key}[/bold]",
-                subtitle="Use --force to regenerate",
+                subtitle="Reusing the existing task; --force to regenerate",
                 border_style="yellow",
             )
         )
@@ -359,8 +359,9 @@ def _publish_task(
     that failed validation. Raises PublishError on failure - an unpublished task is
     lost when an ephemeral sandbox dies, so it is not a success.
 
-    Must run BEFORE the dedupe record is written: a task recorded in create.jsonl but
-    never published cannot be retried without --force.
+    Runs BEFORE the dedupe record is written, so a task that never reached the dataset
+    repo is not recorded as fully published. The caller still records it on failure,
+    flagged published=False, so a rerun republishes it instead of needing --force.
 
     Returns the full PublishResult (callers need `published`, not just the URL: a dry run
     and an already-merged task both yield no URL but mean different things), or None when
@@ -523,8 +524,12 @@ def run_reversal(config: CreateConfig) -> str | None:
         config: Typed configuration with repo, PR number, and options.
 
     Returns:
-        URL of the pull request the task was published to, or None if publishing is
-        disabled (no config.publish), running dry, or the task was skipped by dedupe.
+        URL of the pull request the task was published to, or None when publishing is
+        disabled (no config.publish), when --publish-dry-run suppressed the push, or when
+        the task was already merged into the base branch and needed no PR.
+
+        A dedupe hit does not return early: the recorded task is republished (it may never
+        have reached the dataset repo), or - if its directory is gone - regenerated.
     """
     rich_traceback_install(show_locals=False)
     console = Console()

--- a/src/swegen/create/create.py
+++ b/src/swegen/create/create.py
@@ -23,7 +23,12 @@ from swegen.tools.policy import find_test_network_violations, format_violations
 from swegen.tools.validate_utils import ValidationError, run_nop_oracle
 
 from . import MissingIssueError, PRToHarborPipeline, TrivialPRError
-from .claude_code_runner import ClaudeCodeResult, run_claude_code_session
+from .claude_code_runner import (
+    ClaudeCodeResult,
+    ClaudeRateLimitError,
+    is_rate_limit_failure,
+    run_claude_code_session,
+)
 from .repo_cache import RepoCache
 
 # -----------------------------------------------------------------------------
@@ -708,6 +713,13 @@ def run_reversal(config: CreateConfig) -> str | None:
 
             gen_secs = time.perf_counter() - t0
 
+            # A rate/usage limit is not this task's fault and will hit every following task
+            # until the token is swapped. Raise so the farm aborts and the PR is left
+            # unprocessed for a re-run with a fresh token, rather than reporting the task as
+            # a validation failure and moving on.
+            if cc_result and not cc_result.success and is_rate_limit_failure(cc_result.error_message):
+                raise ClaudeRateLimitError(cc_result.error_message or "Claude rate limit")
+
             if cc_result and cc_result.success:
                 console.print()
                 console.print(f"[green]✓ Task generated and validated in {gen_secs:.1f}s[/green]")
@@ -906,6 +918,21 @@ def run_reversal(config: CreateConfig) -> str | None:
             _cleanup_local_task(console, task_dir)
 
         return pr_url
+    except ClaudeRateLimitError as e:
+        # Anthropic rate/usage limit: not this task's fault, and fatal for a farm run.
+        console.print(
+            Panel(
+                Text(
+                    f"Claude Code hit a rate/usage limit:\n{e}\n\n"
+                    f"Every task draws from the same limit, so this will not clear until the "
+                    f"token or account is swapped. Re-run with a fresh token.",
+                    style="red",
+                ),
+                title="[red]Claude Rate Limit[/red]",
+                border_style="red",
+            )
+        )
+        raise
     except PublishError as e:
         # Already-diagnosed publish failure: show the reason, skip the traceback.
         console.print(

--- a/src/swegen/create/create.py
+++ b/src/swegen/create/create.py
@@ -464,6 +464,7 @@ def run_reversal(config: CreateConfig) -> None:
                 repo=pipeline.repo,
                 head_sha=metadata["head_sha"],
                 repo_url=metadata["repo_url"],
+                base_sha=metadata.get("base_sha"),
             )
             console.print(f"[dim]    Repo at: {repo_path}[/dim]")
 

--- a/src/swegen/create/create.py
+++ b/src/swegen/create/create.py
@@ -17,7 +17,7 @@ from rich.text import Text
 from rich.traceback import install as rich_traceback_install
 
 from swegen.config import CreateConfig
-from swegen.publish import PublishContext, PublishError, TaskSink, build_task_sink
+from swegen.publish import PublishContext, PublishError, PublishResult, TaskSink, build_task_sink
 from swegen.tools.harbor_runner import parse_harbor_outcome, run_harbor_agent
 from swegen.tools.policy import find_test_network_violations, format_violations
 from swegen.tools.validate_utils import ValidationError, run_nop_oracle
@@ -339,7 +339,8 @@ def publish_existing_task(
 
     console.print(f"[cyan]Task already generated; publishing {task_id} from {task_dir}[/cyan]")
     sink = _preflight_publish(console, config, repo)
-    return _publish_task(console, config, sink, repo, pr, task_id, task_dir, metadata={})
+    result = _publish_task(console, config, sink, repo, pr, task_id, task_dir, metadata={})
+    return result.pr_url if result else None
 
 
 def _publish_task(
@@ -351,7 +352,7 @@ def _publish_task(
     task_id: str,
     task_dir: Path,
     metadata: dict,
-) -> str | None:
+) -> PublishResult | None:
     """Publish the validated task as a PR on the dataset repo.
 
     Runs only after every gate has passed, so the dataset repo never receives a task
@@ -361,7 +362,9 @@ def _publish_task(
     Must run BEFORE the dedupe record is written: a task recorded in create.jsonl but
     never published cannot be retried without --force.
 
-    Returns the PR URL, or None when publishing is disabled or dry-run.
+    Returns the full PublishResult (callers need `published`, not just the URL: a dry run
+    and an already-merged task both yield no URL but mean different things), or None when
+    publishing is disabled.
     """
     if config.publish is None:
         return None
@@ -381,7 +384,7 @@ def _publish_task(
         console.print(f"[green]✓ Published {task_id} → {result.pr_url}[/green]")
     elif config.publish.dry_run:
         console.print(f"[cyan]DRY RUN: would publish {task_id} on branch {result.branch}[/cyan]")
-    return result.pr_url
+    return result
 
 
 def _display_summary_panel(
@@ -808,7 +811,7 @@ def run_reversal(config: CreateConfig) -> str | None:
         # Publish before recording the dedupe entry, so a task that never reached the
         # dataset repo is not recorded as fully done.
         try:
-            pr_url = _publish_task(
+            publish_result = _publish_task(
                 console, config, sink, pipeline.repo, config.pr, task_id, task_dir, metadata
             )
         except PublishError:
@@ -829,9 +832,23 @@ def run_reversal(config: CreateConfig) -> str | None:
             )
             raise
 
+        # `published` must reflect what actually reached the dataset repo. A dry run makes
+        # no push and opens no PR, so recording published=True would claim work that was
+        # never done and let a later real run treat the task as fully handled. With
+        # publishing disabled there is nothing to publish, so the record is complete.
+        pr_url = publish_result.pr_url if publish_result else None
+        published = publish_result.published if publish_result else True
+
         # Save state record (non-fatal if fails)
         _save_state_record(
-            state_dir, state_file, repo_key, pipeline.repo, config.pr, task_id, task_dir
+            state_dir,
+            state_file,
+            repo_key,
+            pipeline.repo,
+            config.pr,
+            task_id,
+            task_dir,
+            published=published,
         )
 
         # Display final panels

--- a/src/swegen/create/create.py
+++ b/src/swegen/create/create.py
@@ -17,7 +17,7 @@ from rich.text import Text
 from rich.traceback import install as rich_traceback_install
 
 from swegen.config import CreateConfig
-from swegen.publish import PublishContext, PublishError, build_task_sink
+from swegen.publish import PublishContext, PublishError, TaskSink, build_task_sink
 from swegen.tools.harbor_runner import parse_harbor_outcome, run_harbor_agent
 from swegen.tools.policy import find_test_network_violations, format_violations
 from swegen.tools.validate_utils import ValidationError, run_nop_oracle
@@ -282,9 +282,25 @@ def _save_state_record(
         logger.warning(f"Unexpected error saving state record for {repo_key}: {e}", exc_info=True)
 
 
+def _preflight_publish(console: Console, config: CreateConfig, repo: str) -> TaskSink:
+    """Build the sink and verify the dataset repo is writable, before any work begins.
+
+    Called up front so a bad token fails in seconds rather than after a full Claude Code
+    session and Harbor validation have already been paid for.
+    """
+    sink = build_task_sink(config.publish, repo, state_dir=config.state_dir)
+    if config.publish is not None:
+        console.print(
+            f"[cyan]Publishing to {config.publish.repo} (base: {config.publish.base_branch})[/cyan]"
+        )
+        sink.preflight()
+    return sink
+
+
 def _publish_task(
     console: Console,
     config: CreateConfig,
+    sink: TaskSink,
     repo: str,
     pr: int,
     task_id: str,
@@ -297,9 +313,14 @@ def _publish_task(
     that failed validation. Raises PublishError on failure - an unpublished task is
     lost when an ephemeral sandbox dies, so it is not a success.
 
+    Must run BEFORE the dedupe record is written: a task recorded in create.jsonl but
+    never published cannot be retried without --force.
+
     Returns the PR URL, or None when publishing is disabled or dry-run.
     """
-    sink = build_task_sink(config.publish, repo, state_dir=config.state_dir)
+    if config.publish is None:
+        return None
+
     ctx = PublishContext(
         task_id=task_id,
         task_dir=task_dir,
@@ -308,9 +329,6 @@ def _publish_task(
         source_pr_url=metadata.get("html_url", f"https://github.com/{repo}/pull/{pr}"),
         metadata=metadata,
     )
-
-    if config.publish is None:
-        return None
 
     console.print(Rule(Text("Publish", style="bold blue")))
     result = sink.publish(ctx)
@@ -482,6 +500,10 @@ def run_reversal(config: CreateConfig) -> str | None:
         state_file = state_dir / "create.jsonl"
         if _check_dedupe(console, repo_key, state_file, config.force):
             return
+
+        # Verify the dataset repo is writable before spending a Claude Code session on a
+        # task we would then be unable to publish.
+        sink = _preflight_publish(console, config, pipeline.repo)
 
         harbor_root = config.output
         harbor_root.mkdir(parents=True, exist_ok=True)
@@ -708,15 +730,16 @@ def run_reversal(config: CreateConfig) -> str | None:
             console, harbor_validation_failed, cc_validation_failed, harbor_actually_ran
         )
 
+        # Publish before recording the dedupe entry. A task written to create.jsonl but
+        # never published would be skipped by the next run's dedupe check, leaving no way
+        # to retry the publish without --force.
+        pr_url = _publish_task(
+            console, config, sink, pipeline.repo, config.pr, task_id, task_dir, metadata
+        )
+
         # Save state record (non-fatal if fails)
         _save_state_record(
             state_dir, state_file, repo_key, pipeline.repo, config.pr, task_id, task_dir
-        )
-
-        # Publish the task before anything else can go wrong. On ephemeral sandboxes
-        # this is the only durable copy of the task.
-        pr_url = _publish_task(
-            console, config, pipeline.repo, config.pr, task_id, task_dir, metadata
         )
 
         # Display final panels

--- a/src/swegen/create/orchestrator.py
+++ b/src/swegen/create/orchestrator.py
@@ -200,6 +200,7 @@ class PRToHarborPipeline:
                 repo=self.repo,
                 head_sha=metadata["head_sha"],
                 repo_url=metadata["repo_url"],
+                base_sha=metadata.get("base_sha"),
             )
         logger.info("Repo at: %s", repo_path)
 

--- a/src/swegen/create/repo_cache.py
+++ b/src/swegen/create/repo_cache.py
@@ -24,6 +24,7 @@ class RepoCache:
         repo: str,
         head_sha: str,
         repo_url: str | None = None,
+        base_sha: str | None = None,
     ) -> Path:
         """
         Get cached repo or clone it. Checkout the specified commit.
@@ -32,6 +33,8 @@ class RepoCache:
             repo: Repository in "owner/repo" format
             head_sha: Commit SHA to checkout
             repo_url: Optional clone URL (defaults to https://github.com/{repo}.git)
+            base_sha: Optional base commit SHA. When given, it is fetched alongside
+                head_sha so `git diff base..head` has both ends locally.
 
         Returns:
             Path to the repository root
@@ -42,9 +45,11 @@ class RepoCache:
         if repo_url is None:
             repo_url = f"https://github.com/{repo}.git"
 
+        wanted = [sha for sha in (base_sha, head_sha) if sha]
+
         if repo_path.exists() and (repo_path / ".git").exists():
             self.logger.debug("Using cached repo: %s", repo_path)
-            self._fetch_and_checkout(repo_path, head_sha)
+            self._fetch_and_checkout(repo_path, head_sha, wanted)
         else:
             self.logger.info("Cloning repo to cache: %s -> %s", repo, repo_path)
             self._clone(repo_url, repo_path, head_sha)
@@ -68,10 +73,13 @@ class RepoCache:
         """Clone a repository and checkout the specified commit."""
         repo_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Full clone for maximum CC context
-        self.logger.debug("Cloning %s...", repo_url)
+        # Partial clone: full commit graph and trees (so `git diff base..head` and any
+        # other history walk works), but no file contents up front. Blobs are fetched
+        # lazily, on demand -- which for the two commits we actually diff is a handful
+        # of files instead of every version of every file ever committed.
+        self.logger.debug("Cloning %s (blobless)...", repo_url)
         subprocess.run(
-            ["git", "clone", repo_url, str(repo_path)],
+            ["git", "clone", "--filter=blob:none", repo_url, str(repo_path)],
             check=True,
             capture_output=True,
         )
@@ -79,17 +87,39 @@ class RepoCache:
         # Checkout the target commit
         self._checkout(repo_path, head_sha)
 
-    def _fetch_and_checkout(self, repo_path: Path, head_sha: str) -> None:
-        """Fetch latest and checkout the specified commit."""
-        self.logger.debug("Fetching updates for %s...", repo_path)
+    def _fetch_and_checkout(
+        self,
+        repo_path: Path,
+        head_sha: str,
+        wanted_shas: list[str] | None = None,
+    ) -> None:
+        """Fetch the commits we need and checkout the specified one.
 
-        # Fetch all refs
-        subprocess.run(
-            ["git", "fetch", "--all"],
+        Fetches only the SHAs this task diffs, rather than `--all` (every branch and
+        every tag on every remote) which costs real time per PR on large repos. Falls
+        back to a full fetch if the targeted one fails -- e.g. a force-pushed SHA the
+        remote will no longer serve directly.
+        """
+        shas = wanted_shas or [head_sha]
+        self.logger.debug("Fetching %s for %s...", ", ".join(s[:8] for s in shas), repo_path)
+
+        fetched = subprocess.run(
+            ["git", "fetch", "origin", *shas],
             cwd=str(repo_path),
-            check=True,
+            check=False,
             capture_output=True,
         )
+        if fetched.returncode != 0:
+            self.logger.debug(
+                "Targeted fetch failed (%s); falling back to full fetch",
+                fetched.stderr.decode().strip() if fetched.stderr else "unknown",
+            )
+            subprocess.run(
+                ["git", "fetch", "--all"],
+                cwd=str(repo_path),
+                check=True,
+                capture_output=True,
+            )
 
         # Try to checkout the commit
         self._checkout(repo_path, head_sha)

--- a/src/swegen/create/task_reference.py
+++ b/src/swegen/create/task_reference.py
@@ -87,6 +87,22 @@ class TaskReferenceStore:
             logger.warning(f"Failed to save task reference: {e}")
             return False
 
+    def clear(self, repo: str, task_id: str) -> None:
+        """Drop the reference for `repo` if it points at `task_id`.
+
+        Used when a task directory is deleted (e.g. --cleanup-local): a reference points
+        Claude Code at that directory, so a reference to a removed task would dangle.
+        Non-fatal: a stale reference only degrades to from-scratch generation.
+        """
+        try:
+            references = self._load_references()
+            existing = references.get(repo)
+            if existing is not None and existing.task_id == task_id:
+                del references[repo]
+                self._save_references(references)
+        except Exception as e:
+            logger.warning(f"Failed to clear task reference for {repo}: {e}")
+
     def get(
         self,
         repo: str,

--- a/src/swegen/create/task_skeleton.py
+++ b/src/swegen/create/task_skeleton.py
@@ -40,7 +40,9 @@ def generate_dockerfile(params: SkeletonParams) -> str:
     - Post-patch rebuild (if needed)
     
     Git clone strategy:
-    - Simple + robust: clone, then fetch the exact commit SHA.
+    - Shallow: init an empty repo, then fetch only the exact commit SHA at depth 1.
+      The image needs a single commit's worktree (the .git dir is deleted at the end),
+      so fetching history would be downloaded and then thrown away.
     - NOTE: `head_sha` currently comes from the PR's HEAD branch tip (GitHub API).
     - If the PR was squash-merged/rebased, that commit may not be on any normal branch.
     - In that case, fetching `refs/pull/<n>/head` is a robust fallback without fetching ALL PR refs.
@@ -78,9 +80,11 @@ RUN apt-get update && apt-get install -y \\
 
 WORKDIR /app
 
-# Clone repo at HEAD commit (with fix applied)
-RUN git clone {params.repo_url} src && \\
+# Fetch repo at HEAD commit (with fix applied).
+# Shallow on purpose: only this one commit's worktree is needed, and .git is removed below.
+RUN git init src && \\
     cd src && \\
+    git remote add origin {params.repo_url} && \\
     (git fetch --depth 1 origin {params.head_sha} || git fetch --depth 1 origin "+refs/pull/{params.pr_number}/head:refs/remotes/origin/pr/{params.pr_number}") && \\
     git checkout --detach FETCH_HEAD && \\
     git submodule update --init --recursive

--- a/src/swegen/farm/farm_hand.py
+++ b/src/swegen/farm/farm_hand.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import shutil
 import time
 import traceback
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -19,6 +19,37 @@ from swegen.publish import PublishError
 
 def _now_utc() -> datetime:
     return datetime.now(UTC)
+
+
+def _publish_for_generation(config: FarmConfig):
+    """Publish config for a farm-driven run_reversal, with local cleanup suppressed.
+
+    The farm cleans up itself, AFTER saving a task reference and passing its success gate.
+    Letting run_reversal delete the task dir first would break the gate (missing dir reads
+    as a pipeline failure) and leave the task reference pointing at a deleted directory.
+    """
+    if config.publish is None:
+        return None
+    return replace(config.publish, cleanup_local=False)
+
+
+def _cleanup_local_if_published(
+    config: FarmConfig, task_id: str, tasks_root: Path, console: Console
+) -> None:
+    """Delete the local task copy when --cleanup-local is set and publishing is real.
+
+    Called only on a confirmed publish (a real branch/PR on the dataset repo), so the
+    remote is the surviving copy. Never runs under dry-run - nothing was published.
+    """
+    if config.publish is None or not config.publish.cleanup_local or config.publish.dry_run:
+        return
+    task_dir = tasks_root / task_id
+    try:
+        if task_dir.exists():
+            shutil.rmtree(task_dir)
+            console.print(f"[dim]Removed local task copy {task_dir} (published)[/dim]")
+    except OSError as e:
+        console.print(f"[yellow]Could not remove local task copy {task_dir}: {e}[/yellow]")
 
 
 def _slug(repo: str) -> str:
@@ -77,7 +108,7 @@ def _cleanup_task(task_id: str, tasks_root: Path, console: Console) -> None:
 
 def _classify_failure(stderr: str) -> tuple[str, str]:
     """Classify failure reason and return (category, message).
-    
+
     Categories:
     - trivial: Trivial PR (too small/simple)
     - no_issue: No linked issue
@@ -116,7 +147,7 @@ def _classify_failure(stderr: str) -> tuple[str, str]:
         return "git_error", "Git commit not found (may be force-pushed or deleted)"
     if "git checkout" in lowered:
         return "git_error", "Git checkout failed (repo cache may be corrupted)"
-    
+
     message = (stderr or "Unknown error").replace("\n", " ")
     return "other", message
 
@@ -183,13 +214,15 @@ def _retry_publish_only(
         state_dir=config.state_dir,
         verbose=config.verbose,
         environment=config.environment,
-        publish=config.publish,
+        publish=_publish_for_generation(config),
     )
     record = {"task_id": task_id, "harbor": str(harbor_dir)}
     result = publish_existing_task(console, create_config, config.repo, pr.number, record)
     pr_url = result.pr_url if result else None
 
     _print_success(console, pr, task_id, harbor_dir, pr_url)
+    if result is not None and result.published:
+        _cleanup_local_if_published(config, task_id, harbor_dir.parent, console)
     return TaskResult(
         repo=config.repo,
         pr_number=pr.number,
@@ -300,7 +333,7 @@ def _run_reversal_for_pr_impl(
         require_issue=config.require_issue,
         environment=config.environment,
         enforce_offline_tests=config.enforce_offline_tests,
-        publish=config.publish,
+        publish=_publish_for_generation(config),
     )
 
     # Capture any errors from the pipeline
@@ -336,7 +369,15 @@ def _run_reversal_for_pr_impl(
         error_category = "validation_failed"
         success = False
     except FileExistsError as e:
-        # Task already exists - skip it
+        # A task directory already exists and run_reversal's create.jsonl dedupe did not
+        # republish it - typically because create.jsonl was unavailable (a separate
+        # --state-dir, a cleared .swegen, or a --publish-dry-run run on another disk) while
+        # the validated task survived. With publishing on and the task on disk, republish
+        # it rather than consuming the PR unpublished, symmetric with the publish_failed
+        # retry. If republishing fails, _retry_publish_only raises PublishError, which the
+        # outer handler classifies as publish_failed and the task is preserved.
+        if config.publish is not None and harbor_dir.exists():
+            return _retry_publish_only(pr, config, console, task_id, harbor_dir, start)
         error_msg = f"Task already exists: {str(e)}"
         error_category = "already_exists"
         success = False
@@ -389,6 +430,11 @@ def _run_reversal_for_pr_impl(
                 )
             except Exception as e:
                 console.print(f"[yellow]Warning: Could not save task reference: {e}[/yellow]")
+
+            # Free disk on constrained sandboxes now the task is on the dataset repo. Last,
+            # after the reference save; self-guards on publish enabled + not dry-run. Under
+            # --publish-dry-run this no-ops and the PR is left unprocessed for a real run.
+            _cleanup_local_if_published(config, task_id, tasks_root, console)
 
             return TaskResult(
                 repo=config.repo,

--- a/src/swegen/farm/farm_hand.py
+++ b/src/swegen/farm/farm_hand.py
@@ -12,6 +12,7 @@ from rich.panel import Panel
 
 from swegen.config import CreateConfig, FarmConfig
 from swegen.create import MissingIssueError, TrivialPRError, ValidationError
+from swegen.create.claude_code_runner import ClaudeRateLimitError
 from swegen.create.create import publish_existing_task, run_reversal
 from swegen.create.task_reference import TaskReferenceStore
 from swegen.publish import PublishError
@@ -123,8 +124,10 @@ def _classify_failure(stderr: str) -> tuple[str, str]:
     - other: Unknown/other errors
     """
     lowered = stderr.lower()
-    # Checked first: a publish error wraps git/HTTP output that would otherwise match
-    # the "timeout" or "git" heuristics below.
+    # Checked first: these wrap git/HTTP/SDK output that would otherwise match the
+    # "timeout" or "git" heuristics below.
+    if "claude rate limit" in lowered or "rate_limit_event" in lowered:
+        return "rate_limited", (stderr or "Claude rate limit").replace("\n", " ")
     if "publish failed" in lowered:
         return "publish_failed", (stderr or "Publish failed").replace("\n", " ")
     if "trivial" in stderr:
@@ -346,6 +349,13 @@ def _run_reversal_for_pr_impl(
         # Call the pipeline directly instead of using subprocess
         pr_url = run_reversal(create_config)
         success = True
+    except ClaudeRateLimitError as e:
+        # Anthropic rate/usage limit. Not this PR's fault and it will hit every following
+        # task the same way until the token is swapped, so the farmer stops the run and the
+        # PR is left unprocessed for a re-run with a fresh token.
+        error_msg = f"Claude rate limit: {e}"
+        error_category = "rate_limited"
+        success = False
     except PublishError as e:
         # Task was built and validated but never reached the dataset repo. The farmer
         # stops the run on this category rather than burning a Claude Code session on

--- a/src/swegen/farm/farm_hand.py
+++ b/src/swegen/farm/farm_hand.py
@@ -186,7 +186,8 @@ def _retry_publish_only(
         publish=config.publish,
     )
     record = {"task_id": task_id, "harbor": str(harbor_dir)}
-    pr_url = publish_existing_task(console, create_config, config.repo, pr.number, record)
+    result = publish_existing_task(console, create_config, config.repo, pr.number, record)
+    pr_url = result.pr_url if result else None
 
     _print_success(console, pr, task_id, harbor_dir, pr_url)
     return TaskResult(

--- a/src/swegen/farm/farm_hand.py
+++ b/src/swegen/farm/farm_hand.py
@@ -12,7 +12,7 @@ from rich.panel import Panel
 
 from swegen.config import CreateConfig, FarmConfig
 from swegen.create import MissingIssueError, TrivialPRError, ValidationError
-from swegen.create.create import run_reversal
+from swegen.create.create import publish_existing_task, run_reversal
 from swegen.create.task_reference import TaskReferenceStore
 from swegen.publish import PublishError
 
@@ -157,11 +157,57 @@ def _gate_task(
     return True, f"Task generated successfully at {task_dir}"
 
 
+def _retry_publish_only(
+    pr: PRCandidate,
+    config: FarmConfig,
+    console: Console,
+    task_id: str,
+    harbor_dir: Path,
+    start: float,
+) -> TaskResult:
+    """Republish a task left on disk by an earlier publish failure.
+
+    Regenerating would call run_reversal with force=True, which rmtree's the task
+    directory before rebuilding it - destroying a validated task to redo an hour of
+    Claude Code, and losing it outright if the rebuild then fails. The task already
+    passed every gate; only the push did not.
+    """
+    console.print(
+        f"[cyan]PR #{pr.number}: task {task_id} was validated but never published; "
+        f"retrying publish only (no regeneration)[/cyan]"
+    )
+    create_config = CreateConfig(
+        repo=config.repo,
+        pr=pr.number,
+        output=config.output,
+        state_dir=config.state_dir,
+        verbose=config.verbose,
+        environment=config.environment,
+        publish=config.publish,
+    )
+    record = {"task_id": task_id, "harbor": str(harbor_dir)}
+    pr_url = publish_existing_task(console, create_config, config.repo, pr.number, record)
+
+    _print_success(console, pr, task_id, harbor_dir, pr_url)
+    return TaskResult(
+        repo=config.repo,
+        pr_number=pr.number,
+        task_id=task_id,
+        status="success",
+        message=f"Republished existing task at {harbor_dir}",
+        duration_seconds=round(time.time() - start, 2),
+        timestamp=_now_utc().isoformat(),
+        category=None,
+        pr_url=pr_url,
+    )
+
+
 def _run_reversal_for_pr(
     pr: PRCandidate,
     config: FarmConfig,
     tasks_root: Path,
     console: Console,
+    publish_only: bool = False,
 ) -> TaskResult:
     start = time.time()
     task_id = _task_id(config.repo, pr.number)
@@ -169,8 +215,31 @@ def _run_reversal_for_pr(
 
     # Wrap everything in try-except to catch unexpected errors
     try:
+        # A PR pending publication already has a validated task on disk. Publish it rather
+        # than regenerating, which would delete it.
+        if publish_only and config.publish is not None and harbor_dir.exists():
+            return _retry_publish_only(pr, config, console, task_id, harbor_dir, start)
+
         return _run_reversal_for_pr_impl(
             pr, config, tasks_root, console, task_id, harbor_dir, start
+        )
+    except PublishError as e:
+        # From the publish-only retry above. Never clean up: the task is validated and
+        # only publishing failed, so it must survive for the next attempt.
+        error_msg = f"Publish failed: {e}"
+        console.print(f"[red]✗ PR #{pr.number}: {error_msg}[/red]")
+        console.print(
+            f"[yellow]Keeping task directory {harbor_dir} (validated but unpublished)[/yellow]"
+        )
+        return TaskResult(
+            repo=config.repo,
+            pr_number=pr.number,
+            task_id=task_id,
+            status="failed",
+            message=error_msg,
+            duration_seconds=round(time.time() - start, 2),
+            timestamp=_now_utc().isoformat(),
+            category="publish_failed",
         )
     except Exception as e:
         # Catch any unexpected exception and return proper error

--- a/src/swegen/farm/farm_hand.py
+++ b/src/swegen/farm/farm_hand.py
@@ -14,6 +14,7 @@ from swegen.config import CreateConfig, FarmConfig
 from swegen.create import MissingIssueError, TrivialPRError, ValidationError
 from swegen.create.create import run_reversal
 from swegen.create.task_reference import TaskReferenceStore
+from swegen.publish import PublishError
 
 
 def _now_utc() -> datetime:
@@ -57,6 +58,7 @@ class TaskResult:
     duration_seconds: float
     timestamp: str
     category: str = None  # Category for detailed tracking
+    pr_url: str = None  # URL of the published task PR, if publishing is enabled
 
 
 def _cleanup_task(task_id: str, tasks_root: Path, console: Console) -> None:
@@ -86,9 +88,14 @@ def _classify_failure(stderr: str) -> tuple[str, str]:
     - quota_exceeded: OpenAI quota exceeded
     - timeout: Command timeout
     - git_error: Git checkout/commit errors
+    - publish_failed: Task built but could not be pushed/PR'd
     - other: Unknown/other errors
     """
     lowered = stderr.lower()
+    # Checked first: a publish error wraps git/HTTP output that would otherwise match
+    # the "timeout" or "git" heuristics below.
+    if "publish failed" in lowered:
+        return "publish_failed", (stderr or "Publish failed").replace("\n", " ")
     if "trivial" in stderr:
         return "trivial", "Trivial PR (skipped)"
     if "no linked issue" in lowered or "missingissueerror" in lowered:
@@ -119,10 +126,14 @@ def _print_success(
     pr: PRCandidate,
     task_id: str,
     harbor_dir: Path,
+    pr_url: str | None = None,
 ) -> None:
+    body = f"🎉 Successfully generated task\n[bold]{task_id}[/bold]\nHarbor: {harbor_dir}"
+    if pr_url:
+        body += f"\nPublished: {pr_url}"
     console.print(
         Panel.fit(
-            f"🎉 Successfully generated task\n[bold]{task_id}[/bold]\nHarbor: {harbor_dir}",
+            body,
             title=f"PR #{pr.number}",
             border_style="green",
         )
@@ -219,17 +230,26 @@ def _run_reversal_for_pr_impl(
         require_issue=config.require_issue,
         environment=config.environment,
         enforce_offline_tests=config.enforce_offline_tests,
+        publish=config.publish,
     )
 
     # Capture any errors from the pipeline
     success = False
     error_msg = ""
     error_category = None
+    pr_url: str | None = None
 
     try:
         # Call the pipeline directly instead of using subprocess
-        run_reversal(create_config)
+        pr_url = run_reversal(create_config)
         success = True
+    except PublishError as e:
+        # Task was built and validated but never reached the dataset repo. The farmer
+        # stops the run on this category rather than burning a Claude Code session on
+        # the next PR just to fail at the same wall.
+        error_msg = f"Publish failed: {e}"
+        error_category = "publish_failed"
+        success = False
     except TrivialPRError as e:
         # Trivial PR - not an error, just skip it
         error_msg = str(e)
@@ -287,7 +307,7 @@ def _run_reversal_for_pr_impl(
         duration = time.time() - start
         gate_ok, gate_msg = _gate_task(task_id, tasks_root)
         if gate_ok:
-            _print_success(console, pr, task_id, harbor_dir)
+            _print_success(console, pr, task_id, harbor_dir, pr_url)
 
             # Save task reference for future PRs
             try:
@@ -309,6 +329,7 @@ def _run_reversal_for_pr_impl(
                 duration_seconds=round(duration, 2),
                 timestamp=_now_utc().isoformat(),
                 category=None,
+                pr_url=pr_url,
             )
 
         # Gate failed
@@ -329,7 +350,17 @@ def _run_reversal_for_pr_impl(
 
     # Pipeline failed
     failure_category, failure_reason = _classify_failure(error_msg)
-    _cleanup_task(task_id, tasks_root, console)
+
+    if failure_category == "publish_failed":
+        # The task itself is valid - it passed every gate and only the push/PR failed.
+        # Keep it on disk so it can be published by hand or by a re-run.
+        console.print(
+            f"[yellow]Keeping task directory {tasks_root / task_id} "
+            f"(validated but unpublished)[/yellow]"
+        )
+    else:
+        _cleanup_task(task_id, tasks_root, console)
+
     console.print(f"[red]✗ PR #{pr.number}: {failure_reason}[/red]")
     return TaskResult(
         repo=config.repo,

--- a/src/swegen/farm/farm_hand.py
+++ b/src/swegen/farm/farm_hand.py
@@ -14,6 +14,7 @@ from swegen.config import CreateConfig, FarmConfig
 from swegen.create import MissingIssueError, TrivialPRError, ValidationError
 from swegen.create.claude_code_runner import ClaudeRateLimitError
 from swegen.create.create import publish_existing_task, run_reversal
+from swegen.create.task_reference import TaskReferenceStore
 from swegen.publish import PublishError
 
 
@@ -24,9 +25,10 @@ def _now_utc() -> datetime:
 def _publish_for_generation(config: FarmConfig):
     """Publish config for a farm-driven run_reversal, with local cleanup suppressed.
 
-    The farm cleans up itself, AFTER saving a task reference and passing its success gate.
-    Letting run_reversal delete the task dir first would break the gate (missing dir reads
-    as a pipeline failure) and leave the task reference pointing at a deleted directory.
+    The farm cleans up itself, after its success gate passes. Letting run_reversal delete
+    the task dir first would break that gate (a missing dir reads as a pipeline failure).
+    run_reversal still saves the task reference (before publish); the farm's own cleanup
+    clears that reference when it deletes the task, so nothing dangles.
     """
     if config.publish is None:
         return None
@@ -50,6 +52,12 @@ def _cleanup_local_if_published(
             console.print(f"[dim]Removed local task copy {task_dir} (published)[/dim]")
     except OSError as e:
         console.print(f"[yellow]Could not remove local task copy {task_dir}: {e}[/yellow]")
+
+    # run_reversal saved a task reference before publishing (it does not see the farm's
+    # cleanup intent, since the generation config suppresses cleanup_local). Drop it now,
+    # or it would point Claude Code at the directory we just deleted.
+    reference_file = Path(config.state_dir) / "task_references.json"
+    TaskReferenceStore(reference_file=reference_file).clear(config.repo, task_id)
 
 
 def _slug(repo: str) -> str:

--- a/src/swegen/farm/farm_hand.py
+++ b/src/swegen/farm/farm_hand.py
@@ -14,7 +14,6 @@ from swegen.config import CreateConfig, FarmConfig
 from swegen.create import MissingIssueError, TrivialPRError, ValidationError
 from swegen.create.claude_code_runner import ClaudeRateLimitError
 from swegen.create.create import publish_existing_task, run_reversal
-from swegen.create.task_reference import TaskReferenceStore
 from swegen.publish import PublishError
 
 
@@ -430,20 +429,13 @@ def _run_reversal_for_pr_impl(
         if gate_ok:
             _print_success(console, pr, task_id, harbor_dir, pr_url)
 
-            # Save task reference for future PRs
-            try:
-                reference_store = TaskReferenceStore()
-                reference_store.save(
-                    repo=config.repo,
-                    task_id=task_id,
-                    pr_number=pr.number,
-                )
-            except Exception as e:
-                console.print(f"[yellow]Warning: Could not save task reference: {e}[/yellow]")
+            # The task reference is saved inside run_reversal, at validation time and before
+            # publish, so it also covers a task that fails to publish or is republished on
+            # retry (which never calls run_reversal). Nothing to save here.
 
-            # Free disk on constrained sandboxes now the task is on the dataset repo. Last,
-            # after the reference save; self-guards on publish enabled + not dry-run. Under
-            # --publish-dry-run this no-ops and the PR is left unprocessed for a real run.
+            # Free disk on constrained sandboxes now the task is on the dataset repo.
+            # Self-guards on publish enabled + not dry-run. Under --publish-dry-run this
+            # no-ops and the PR is left unprocessed for a real run.
             _cleanup_local_if_published(config, task_id, tasks_root, console)
 
             return TaskResult(

--- a/src/swegen/farm/fetcher.py
+++ b/src/swegen/farm/fetcher.py
@@ -209,14 +209,19 @@ class StreamingPRFetcher:
 
                 # Skip if this PR was created after our resume time
                 # (we're working backwards, so we only want PRs created before the resume point)
-                # Exception: a PR whose task was built but never published is always retried.
-                # The stream is created-desc, so such a PR is normally older than the cursor
-                # and passes anyway - but it shares the cursor's timestamp on a tie, and >=
-                # would otherwise strand it forever.
+                # Exception: a PR left pending on purpose - its task was built but never
+                # published, or Claude rate-limited the run before it could be farmed - is
+                # always retried. The stream is created-desc, so such a PR is normally older
+                # than the cursor and passes anyway, but it shares the cursor's timestamp on a
+                # tie, and >= would otherwise strand it forever.
+                pending_retry = (
+                    pr_number in self.state.publish_failed_prs
+                    or pr_number in self.state.claude_rate_limited_prs
+                )
                 if resume_from_time is not None and created_at:
                     pr_created_dt = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
                     resume_dt = datetime.fromisoformat(resume_from_time.replace("Z", "+00:00"))
-                    if pr_created_dt >= resume_dt and pr_number not in self.state.publish_failed_prs:
+                    if pr_created_dt >= resume_dt and not pending_retry:
                         skipped_stats["after_resume_time"] += 1
                         continue
 

--- a/src/swegen/farm/fetcher.py
+++ b/src/swegen/farm/fetcher.py
@@ -209,10 +209,14 @@ class StreamingPRFetcher:
 
                 # Skip if this PR was created after our resume time
                 # (we're working backwards, so we only want PRs created before the resume point)
+                # Exception: a PR whose task was built but never published is always retried.
+                # The stream is created-desc, so such a PR is normally older than the cursor
+                # and passes anyway - but it shares the cursor's timestamp on a tie, and >=
+                # would otherwise strand it forever.
                 if resume_from_time is not None and created_at:
                     pr_created_dt = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
                     resume_dt = datetime.fromisoformat(resume_from_time.replace("Z", "+00:00"))
-                    if pr_created_dt >= resume_dt:
+                    if pr_created_dt >= resume_dt and pr_number not in self.state.publish_failed_prs:
                         skipped_stats["after_resume_time"] += 1
                         continue
 

--- a/src/swegen/farm/state.py
+++ b/src/swegen/farm/state.py
@@ -144,14 +144,28 @@ class StreamState:
                 self.timeout_prs.add(pr_number)
             elif category == "git_error":
                 self.git_error_prs.add(pr_number)
-            elif category == "publish_failed":
-                self.publish_failed_prs.add(pr_number)
             else:
                 # Other/unknown error
                 self.other_failed_prs[pr_number] = message or "Unknown error"
         
         self.last_pr_number = pr_number
         self.last_created_at = created_at
+        self.last_updated = datetime.now(UTC).isoformat()
+
+    def mark_publish_failed(self, pr_number: int) -> None:
+        """Record a publish failure WITHOUT consuming the PR.
+
+        Deliberately does not add to processed_prs or advance last_created_at: the task
+        was generated and validated, and only the push/PR failed. Leaving the PR
+        unprocessed means the next run retries it, and the publish path is idempotent -
+        it finds the stale branch, recommits, and opens the PR that never got created.
+
+        This is the recovery path for a push that succeeds and a create_pr that then
+        fails, which would otherwise strand a branch on the remote with no PR and no way
+        for the farm to reach it again.
+        """
+        self.failed += 1
+        self.publish_failed_prs.add(pr_number)
         self.last_updated = datetime.now(UTC).isoformat()
 
     def to_dict(self) -> dict:

--- a/src/swegen/farm/state.py
+++ b/src/swegen/farm/state.py
@@ -99,6 +99,37 @@ class StreamState:
         if self.other_failed_prs is None:
             self.other_failed_prs = {}
 
+    # Every set holding a per-PR failure/skip outcome. A PR belongs to at most one of
+    # these, plus successful_prs and other_failed_prs, which are handled alongside.
+    _FAILURE_SETS = (
+        "trivial_prs",
+        "no_issue_prs",
+        "no_tests_prs",
+        "validation_failed_prs",
+        "already_exists_prs",
+        "rate_limit_prs",
+        "quota_exceeded_prs",
+        "timeout_prs",
+        "git_error_prs",
+        "publish_failed_prs",
+    )
+
+    def _clear_outcome(self, pr_number: int, *, keep_success: bool = False) -> None:
+        """Remove `pr_number` from every outcome bucket.
+
+        A PR has exactly one outcome. Recording a new one must evict the old, or the PR
+        sits in two buckets at once and _recompute_counters counts it as both successful
+        and failed. `keep_success` preserves successful_prs/task_pr_urls when the new
+        outcome is itself a success, so a success re-recorded without a task_id does not
+        erase the task_id from the first one.
+        """
+        for name in self._FAILURE_SETS:
+            getattr(self, name).discard(pr_number)
+        self.other_failed_prs.pop(pr_number, None)
+        if not keep_success:
+            self.successful_prs.pop(pr_number, None)
+            self.task_pr_urls.pop(pr_number, None)
+
     def mark_processed(
         self, pr_number: int, created_at: str, success: bool, task_id: str = None,
         category: str = None, message: str = None, pr_url: str = None
@@ -117,10 +148,10 @@ class StreamState:
         self.processed_prs.add(pr_number)
         self.total_processed += 1
 
-        # A PR reaching a terminal outcome is no longer a pending publish failure. Without
-        # this, a successful retry would leave the PR in publish_failed_prs forever and the
-        # durable state / summaries would keep reporting a failure that has been resolved.
-        self.publish_failed_prs.discard(pr_number)
+        # This outcome supersedes any earlier one - notably a pending publish failure that
+        # a retry has now resolved. Leaving the PR in its old bucket would report a failure
+        # that no longer exists, and double-count it against the new outcome.
+        self._clear_outcome(pr_number, keep_success=success)
 
         if success:
             self.successful += 1
@@ -160,19 +191,10 @@ class StreamState:
 
     def _failed_pr_numbers(self) -> set[int]:
         """Every PR with a recorded failure or skip, across all categories."""
-        return (
-            self.trivial_prs
-            | self.no_issue_prs
-            | self.no_tests_prs
-            | self.validation_failed_prs
-            | self.already_exists_prs
-            | self.rate_limit_prs
-            | self.quota_exceeded_prs
-            | self.timeout_prs
-            | self.git_error_prs
-            | self.publish_failed_prs
-            | set(self.other_failed_prs)
-        )
+        failed: set[int] = set(self.other_failed_prs)
+        for name in self._FAILURE_SETS:
+            failed |= getattr(self, name)
+        return failed
 
     def _recompute_counters(self) -> None:
         """Derive counters from the recorded sets rather than incrementing blindly.
@@ -198,6 +220,7 @@ class StreamState:
         fails, which would otherwise strand a branch on the remote with no PR and no way
         for the farm to reach it again.
         """
+        self._clear_outcome(pr_number)
         self.publish_failed_prs.add(pr_number)
         self.last_updated = datetime.now(UTC).isoformat()
         self._recompute_counters()
@@ -223,27 +246,41 @@ class StreamState:
         if other.repo != self.repo:
             raise ValueError(f"Cannot merge state for {other.repo} into {self.repo}")
 
+        # A PR carries exactly ONE outcome. Where both sides judged the same PR, the
+        # receiver's verdict stands - it is the fresher state - so `other` may never add
+        # that PR to a second, contradictory bucket. Snapshot our verdicts before merging.
+        own_failed = self._failed_pr_numbers()
+        own_verdicts = set(self.successful_prs) | own_failed
+
         self.processed_prs |= other.processed_prs
         self.skip_list_prs |= other.skip_list_prs
-        self.trivial_prs |= other.trivial_prs
-        self.no_issue_prs |= other.no_issue_prs
-        self.no_tests_prs |= other.no_tests_prs
-        self.validation_failed_prs |= other.validation_failed_prs
-        self.already_exists_prs |= other.already_exists_prs
-        self.rate_limit_prs |= other.rate_limit_prs
-        self.quota_exceeded_prs |= other.quota_exceeded_prs
-        self.timeout_prs |= other.timeout_prs
-        self.git_error_prs |= other.git_error_prs
+        for name in self._FAILURE_SETS:
+            getattr(self, name).update(getattr(other, name) - own_verdicts)
 
         # Receiver wins on key collision; callers pass the staler state as `other`.
-        self.successful_prs = {**other.successful_prs, **self.successful_prs}
+        self.successful_prs = {
+            **{pr: t for pr, t in other.successful_prs.items() if pr not in own_failed},
+            **self.successful_prs,
+        }
         self.task_pr_urls = {**other.task_pr_urls, **self.task_pr_urls}
-        self.other_failed_prs = {**other.other_failed_prs, **self.other_failed_prs}
+        self.other_failed_prs = {
+            **{pr: m for pr, m in other.other_failed_prs.items() if pr not in own_verdicts},
+            **self.other_failed_prs,
+        }
 
-        # A PR published by either writer is no longer a pending publish failure.
-        self.publish_failed_prs |= other.publish_failed_prs
+        # Anything now recorded as successful cannot also be a failure. This scrubs the
+        # staler side's failure verdict for PRs we later saw succeed; without it a PR sits
+        # in two buckets and _recompute_counters scores it as both successful and failed.
+        for pr_number in set(self.successful_prs):
+            for name in self._FAILURE_SETS:
+                getattr(self, name).discard(pr_number)
+            self.other_failed_prs.pop(pr_number, None)
+
+        # A PR still pending publication must stay UNCONSUMED, even though the staler side
+        # recorded it as processed. Subtracting the other way would let `other.processed_prs`
+        # swallow our pending retry and the PR would never be farmed again.
         self.publish_failed_prs -= set(self.successful_prs)
-        self.publish_failed_prs -= self.processed_prs
+        self.processed_prs -= self.publish_failed_prs
 
         self.total_fetched = max(self.total_fetched, other.total_fetched)
         if other.last_created_at and (

--- a/src/swegen/farm/state.py
+++ b/src/swegen/farm/state.py
@@ -56,6 +56,10 @@ class StreamState:
     successful_prs: dict[int, str] = None  # PR# -> task_id
     task_pr_urls: dict[int, str] = None  # PR# -> URL of the published task PR
     publish_failed_prs: set[int] = None
+    # Claude rate/usage limit aborted the run on this PR. Distinct from rate_limit_prs
+    # (GitHub API limit, a consumed skip). Not consumed: exempted from the resume-time
+    # skip so a re-run with a fresh token retries it, like publish_failed_prs.
+    claude_rate_limited_prs: set[int] = None
     trivial_prs: set[int] = None
     no_issue_prs: set[int] = None
     no_tests_prs: set[int] = None
@@ -78,6 +82,8 @@ class StreamState:
             self.task_pr_urls = {}
         if self.publish_failed_prs is None:
             self.publish_failed_prs = set()
+        if self.claude_rate_limited_prs is None:
+            self.claude_rate_limited_prs = set()
         if self.trivial_prs is None:
             self.trivial_prs = set()
         if self.no_issue_prs is None:
@@ -112,6 +118,7 @@ class StreamState:
         "timeout_prs",
         "git_error_prs",
         "publish_failed_prs",
+        "claude_rate_limited_prs",
     )
 
     def _clear_outcome(self, pr_number: int, *, keep_success: bool = False) -> None:
@@ -233,6 +240,21 @@ class StreamState:
         self.last_updated = datetime.now(UTC).isoformat()
         self._recompute_counters()
 
+    def mark_claude_rate_limited(self, pr_number: int) -> None:
+        """Record that Claude's rate/usage limit aborted the run on this PR, without
+        consuming it.
+
+        Like mark_publish_failed: nothing was durably done, so the PR must not be counted
+        as processed, and the fetcher exempts claude_rate_limited_prs from the resume-time
+        skip so a re-run with a fresh token retries it even on a timestamp tie with the
+        cursor. A later successful run clears it via mark_processed -> _clear_outcome.
+        """
+        self._clear_outcome(pr_number)
+        self.processed_prs.discard(pr_number)
+        self.claude_rate_limited_prs.add(pr_number)
+        self.last_updated = datetime.now(UTC).isoformat()
+        self._recompute_counters()
+
     def merge_from(self, other: StreamState) -> None:
         """Union `other` into this state, in place.
 
@@ -285,11 +307,13 @@ class StreamState:
                 getattr(self, name).discard(pr_number)
             self.other_failed_prs.pop(pr_number, None)
 
-        # A PR still pending publication must stay UNCONSUMED, even though the staler side
-        # recorded it as processed. Subtracting the other way would let `other.processed_prs`
-        # swallow our pending retry and the PR would never be farmed again.
+        # A PR still pending (publish failed, or Claude rate-limited) must stay UNCONSUMED,
+        # even though the staler side recorded it as processed. Subtracting the other way
+        # would let `other.processed_prs` swallow our pending retry and the PR would never
+        # be farmed again.
         self.publish_failed_prs -= set(self.successful_prs)
-        self.processed_prs -= self.publish_failed_prs
+        self.claude_rate_limited_prs -= set(self.successful_prs)
+        self.processed_prs -= self.publish_failed_prs | self.claude_rate_limited_prs
 
         self.total_fetched = max(self.total_fetched, other.total_fetched)
         if other.last_created_at and (
@@ -317,6 +341,7 @@ class StreamState:
             "successful_prs": {str(k): v for k, v in self.successful_prs.items()},
             "task_pr_urls": {str(k): v for k, v in self.task_pr_urls.items()},
             "publish_failed_prs": list(self.publish_failed_prs),
+            "claude_rate_limited_prs": list(self.claude_rate_limited_prs),
             "trivial_prs": list(self.trivial_prs),
             "no_issue_prs": list(self.no_issue_prs),
             "no_tests_prs": list(self.no_tests_prs),
@@ -357,6 +382,7 @@ class StreamState:
             successful_prs={int(k): v for k, v in data.get("successful_prs", {}).items()},
             task_pr_urls={int(k): v for k, v in data.get("task_pr_urls", {}).items()},
             publish_failed_prs=set(data.get("publish_failed_prs", [])),
+            claude_rate_limited_prs=set(data.get("claude_rate_limited_prs", [])),
             trivial_prs=set(data.get("trivial_prs", [])),
             no_issue_prs=set(data.get("no_issue_prs", [])),
             no_tests_prs=set(data.get("no_tests_prs", [])),
@@ -368,11 +394,11 @@ class StreamState:
             git_error_prs=set(data.get("git_error_prs", [])),
             other_failed_prs={int(k): v for k, v in data.get("other_failed_prs", {}).items()},
         )
-        # Enforce the invariant on load, not just via merge_from/mark_publish_failed. A PR
-        # pending publication must not also be in processed_prs, or the fetcher skips it as
-        # already-processed (that check runs before the publish_failed exemption) and never
-        # retries. Guards against legacy state files and hand edits.
-        state.processed_prs -= state.publish_failed_prs
+        # Enforce the invariant on load, not just via merge_from/mark_*. A PR still pending
+        # (publish failed, or Claude rate-limited) must not also be in processed_prs, or the
+        # fetcher skips it as already-processed (that check runs before the resume-skip
+        # exemption) and never retries. Guards against legacy state files and hand edits.
+        state.processed_prs -= state.publish_failed_prs | state.claude_rate_limited_prs
         state._recompute_counters()
         return state
 

--- a/src/swegen/farm/state.py
+++ b/src/swegen/farm/state.py
@@ -211,8 +211,8 @@ class StreamState:
     def mark_publish_failed(self, pr_number: int) -> None:
         """Record a publish failure WITHOUT consuming the PR.
 
-        Deliberately does not add to processed_prs or advance last_created_at: the task
-        was generated and validated, and only the push/PR failed. Leaving the PR
+        Removes the PR from processed_prs (if present) and does not advance last_created_at:
+        the task was generated and validated, and only the push/PR failed. Leaving the PR
         unprocessed means the next run retries it - publish-only, reusing the task already
         on disk rather than regenerating it - and the publish path is idempotent, so it
         refreshes the branch this task left behind and opens the PR that never got created.
@@ -225,6 +225,10 @@ class StreamState:
         cursor's timestamp is still retried rather than stranded.
         """
         self._clear_outcome(pr_number)
+        # A pending publish is by definition not "done". If the PR was previously recorded
+        # as processed, remove it: the fetcher skips processed_prs BEFORE the publish_failed
+        # exemption, so leaving it in both would make the PR skipped and never retried.
+        self.processed_prs.discard(pr_number)
         self.publish_failed_prs.add(pr_number)
         self.last_updated = datetime.now(UTC).isoformat()
         self._recompute_counters()
@@ -364,6 +368,11 @@ class StreamState:
             git_error_prs=set(data.get("git_error_prs", [])),
             other_failed_prs={int(k): v for k, v in data.get("other_failed_prs", {}).items()},
         )
+        # Enforce the invariant on load, not just via merge_from/mark_publish_failed. A PR
+        # pending publication must not also be in processed_prs, or the fetcher skips it as
+        # already-processed (that check runs before the publish_failed exemption) and never
+        # retries. Guards against legacy state files and hand edits.
+        state.processed_prs -= state.publish_failed_prs
         state._recompute_counters()
         return state
 

--- a/src/swegen/farm/state.py
+++ b/src/swegen/farm/state.py
@@ -213,12 +213,16 @@ class StreamState:
 
         Deliberately does not add to processed_prs or advance last_created_at: the task
         was generated and validated, and only the push/PR failed. Leaving the PR
-        unprocessed means the next run retries it, and the publish path is idempotent -
-        it finds the stale branch, recommits, and opens the PR that never got created.
+        unprocessed means the next run retries it - publish-only, reusing the task already
+        on disk rather than regenerating it - and the publish path is idempotent, so it
+        refreshes the branch this task left behind and opens the PR that never got created.
 
         This is the recovery path for a push that succeeds and a create_pr that then
         fails, which would otherwise strand a branch on the remote with no PR and no way
         for the farm to reach it again.
+
+        StreamingPRFetcher exempts these PRs from the resume-time skip, so a PR sharing the
+        cursor's timestamp is still retried rather than stranded.
         """
         self._clear_outcome(pr_number)
         self.publish_failed_prs.add(pr_number)
@@ -229,14 +233,15 @@ class StreamState:
         """Union `other` into this state, in place.
 
         THE RECEIVER WINS on key collisions, so call this on the FRESHER of the two states
-        and pass the staler one. Sets are unioned either way, but per-PR values
-        (successful_prs, task_pr_urls, other_failed_prs) can genuinely differ - a task
-        republished after its first PR was closed has a new URL - and the newer value must
-        survive.
+        and pass the staler one. Sets are unioned either way - no PR is ever lost whichever
+        way round it runs - but per-PR values (successful_prs, task_pr_urls,
+        other_failed_prs) can genuinely differ, and a PR judged a failure by one side and a
+        success by the other must end up with exactly one verdict.
 
-        Used when a state push is rejected because the remote moved: rather than
-        hard-overwriting a cursor another writer just published, we take the union so no
-        processed PR is forgotten.
+        Two callers, both of which must pick the fresher receiver:
+          * GitStateStore._write_and_push, when a push is rejected because the remote moved
+            - rather than hard-overwriting a cursor another writer just published
+          * GitStateStore.load, folding the local mirror and the state branch together
 
         last_created_at takes the NEWER of the two. The stream is created-descending and
         skips PRs created at or after the cursor, so a newer cursor skips less. Anything

--- a/src/swegen/farm/state.py
+++ b/src/swegen/farm/state.py
@@ -117,6 +117,11 @@ class StreamState:
         self.processed_prs.add(pr_number)
         self.total_processed += 1
 
+        # A PR reaching a terminal outcome is no longer a pending publish failure. Without
+        # this, a successful retry would leave the PR in publish_failed_prs forever and the
+        # durable state / summaries would keep reporting a failure that has been resolved.
+        self.publish_failed_prs.discard(pr_number)
+
         if success:
             self.successful += 1
             if task_id:
@@ -151,6 +156,35 @@ class StreamState:
         self.last_pr_number = pr_number
         self.last_created_at = created_at
         self.last_updated = datetime.now(UTC).isoformat()
+        self._recompute_counters()
+
+    def _failed_pr_numbers(self) -> set[int]:
+        """Every PR with a recorded failure or skip, across all categories."""
+        return (
+            self.trivial_prs
+            | self.no_issue_prs
+            | self.no_tests_prs
+            | self.validation_failed_prs
+            | self.already_exists_prs
+            | self.rate_limit_prs
+            | self.quota_exceeded_prs
+            | self.timeout_prs
+            | self.git_error_prs
+            | self.publish_failed_prs
+            | set(self.other_failed_prs)
+        )
+
+    def _recompute_counters(self) -> None:
+        """Derive counters from the recorded sets rather than incrementing blindly.
+
+        Counters must be derived, not accumulated: a PR can move between categories (a
+        publish failure that later succeeds on retry), and a merge can union two states.
+        Incremental counting drifts in both cases and the durable state reports failures
+        that no longer exist.
+        """
+        self.successful = len(self.successful_prs)
+        self.failed = len(self._failed_pr_numbers())
+        self.total_processed = len(self.processed_prs)
 
     def mark_publish_failed(self, pr_number: int) -> None:
         """Record a publish failure WITHOUT consuming the PR.
@@ -164,9 +198,56 @@ class StreamState:
         fails, which would otherwise strand a branch on the remote with no PR and no way
         for the farm to reach it again.
         """
-        self.failed += 1
         self.publish_failed_prs.add(pr_number)
         self.last_updated = datetime.now(UTC).isoformat()
+        self._recompute_counters()
+
+    def merge_from(self, other: StreamState) -> None:
+        """Union `other` into this state, in place.
+
+        Used when a state push is rejected because the remote moved: rather than
+        hard-overwriting a cursor another writer just published, we take the union so no
+        processed PR is forgotten.
+
+        last_created_at takes the NEWER of the two. The stream is created-descending and
+        skips PRs created at or after the cursor, so a newer cursor skips less. Anything
+        it re-visits is caught by processed_prs, which is the authoritative skip list. An
+        older cursor could permanently skip PRs neither writer had processed.
+        """
+        if other.repo != self.repo:
+            raise ValueError(f"Cannot merge state for {other.repo} into {self.repo}")
+
+        self.processed_prs |= other.processed_prs
+        self.skip_list_prs |= other.skip_list_prs
+        self.trivial_prs |= other.trivial_prs
+        self.no_issue_prs |= other.no_issue_prs
+        self.no_tests_prs |= other.no_tests_prs
+        self.validation_failed_prs |= other.validation_failed_prs
+        self.already_exists_prs |= other.already_exists_prs
+        self.rate_limit_prs |= other.rate_limit_prs
+        self.quota_exceeded_prs |= other.quota_exceeded_prs
+        self.timeout_prs |= other.timeout_prs
+        self.git_error_prs |= other.git_error_prs
+
+        # Ours wins on key collision: this run has the more recent outcome.
+        self.successful_prs = {**other.successful_prs, **self.successful_prs}
+        self.task_pr_urls = {**other.task_pr_urls, **self.task_pr_urls}
+        self.other_failed_prs = {**other.other_failed_prs, **self.other_failed_prs}
+
+        # A PR published by either writer is no longer a pending publish failure.
+        self.publish_failed_prs |= other.publish_failed_prs
+        self.publish_failed_prs -= set(self.successful_prs)
+        self.publish_failed_prs -= self.processed_prs
+
+        self.total_fetched = max(self.total_fetched, other.total_fetched)
+        if other.last_created_at and (
+            not self.last_created_at or other.last_created_at > self.last_created_at
+        ):
+            self.last_created_at = other.last_created_at
+            self.last_pr_number = other.last_pr_number
+
+        self.last_updated = datetime.now(UTC).isoformat()
+        self._recompute_counters()
 
     def to_dict(self) -> dict:
         """Convert to dict for JSON serialization."""

--- a/src/swegen/farm/state.py
+++ b/src/swegen/farm/state.py
@@ -287,13 +287,17 @@ class StreamState:
     def from_dict(cls, data: dict) -> StreamState:
         """Load state from a dict.
 
+        Counters are re-derived from the detailed sets rather than trusted as stored, so a
+        state file written before counters became derived - or hand-edited - cannot make
+        the summary panels report totals that contradict the recorded PRs.
+
         Args:
             data: Dict previously created by to_dict()
 
         Returns:
             StreamState instance
         """
-        return cls(
+        state = cls(
             repo=data["repo"],
             processed_prs=set(data.get("processed_prs", [])),
             total_fetched=data.get("total_fetched", 0),
@@ -318,6 +322,8 @@ class StreamState:
             git_error_prs=set(data.get("git_error_prs", [])),
             other_failed_prs={int(k): v for k, v in data.get("other_failed_prs", {}).items()},
         )
+        state._recompute_counters()
+        return state
 
     def save(self, state_file: Path) -> None:
         """Save state to a JSON file.

--- a/src/swegen/farm/state.py
+++ b/src/swegen/farm/state.py
@@ -27,6 +27,8 @@ class StreamState:
         
         # Detailed categorization
         successful_prs: dict[int, str] = None  # PR# -> task_id
+        task_pr_urls: dict[int, str] = None  # PR# -> URL of the published task PR
+        publish_failed_prs: set[int] = None  # Task built but could not be published
         trivial_prs: set[int] = None  # Trivial PRs (too small/simple)
         no_issue_prs: set[int] = None  # PRs without linked issues
         no_tests_prs: set[int] = None  # PRs that don't modify tests
@@ -52,6 +54,8 @@ class StreamState:
     
     # Detailed categorization
     successful_prs: dict[int, str] = None  # PR# -> task_id
+    task_pr_urls: dict[int, str] = None  # PR# -> URL of the published task PR
+    publish_failed_prs: set[int] = None
     trivial_prs: set[int] = None
     no_issue_prs: set[int] = None
     no_tests_prs: set[int] = None
@@ -70,6 +74,10 @@ class StreamState:
             self.skip_list_prs = set()
         if self.successful_prs is None:
             self.successful_prs = {}
+        if self.task_pr_urls is None:
+            self.task_pr_urls = {}
+        if self.publish_failed_prs is None:
+            self.publish_failed_prs = set()
         if self.trivial_prs is None:
             self.trivial_prs = set()
         if self.no_issue_prs is None:
@@ -92,8 +100,8 @@ class StreamState:
             self.other_failed_prs = {}
 
     def mark_processed(
-        self, pr_number: int, created_at: str, success: bool, task_id: str = None, 
-        category: str = None, message: str = None
+        self, pr_number: int, created_at: str, success: bool, task_id: str = None,
+        category: str = None, message: str = None, pr_url: str = None
     ) -> None:
         """Mark a PR as processed and update counters.
 
@@ -104,14 +112,17 @@ class StreamState:
             task_id: Task ID if successful (for tracking)
             category: Category of result (for detailed stats)
             message: Error/skip message (for other_failed category)
+            pr_url: URL of the published task PR, if the task was published
         """
         self.processed_prs.add(pr_number)
         self.total_processed += 1
-        
+
         if success:
             self.successful += 1
             if task_id:
                 self.successful_prs[pr_number] = task_id
+            if pr_url:
+                self.task_pr_urls[pr_number] = pr_url
         else:
             self.failed += 1
             # Categorize the failure/skip
@@ -133,6 +144,8 @@ class StreamState:
                 self.timeout_prs.add(pr_number)
             elif category == "git_error":
                 self.git_error_prs.add(pr_number)
+            elif category == "publish_failed":
+                self.publish_failed_prs.add(pr_number)
             else:
                 # Other/unknown error
                 self.other_failed_prs[pr_number] = message or "Unknown error"
@@ -155,6 +168,8 @@ class StreamState:
             "last_updated": self.last_updated,
             # Detailed breakdown
             "successful_prs": {str(k): v for k, v in self.successful_prs.items()},
+            "task_pr_urls": {str(k): v for k, v in self.task_pr_urls.items()},
+            "publish_failed_prs": list(self.publish_failed_prs),
             "trivial_prs": list(self.trivial_prs),
             "no_issue_prs": list(self.no_issue_prs),
             "no_tests_prs": list(self.no_tests_prs),
@@ -189,6 +204,8 @@ class StreamState:
             last_updated=data.get("last_updated"),
             # Detailed breakdown
             successful_prs={int(k): v for k, v in data.get("successful_prs", {}).items()},
+            task_pr_urls={int(k): v for k, v in data.get("task_pr_urls", {}).items()},
+            publish_failed_prs=set(data.get("publish_failed_prs", [])),
             trivial_prs=set(data.get("trivial_prs", [])),
             no_issue_prs=set(data.get("no_issue_prs", [])),
             no_tests_prs=set(data.get("no_tests_prs", [])),

--- a/src/swegen/farm/state.py
+++ b/src/swegen/farm/state.py
@@ -205,6 +205,12 @@ class StreamState:
     def merge_from(self, other: StreamState) -> None:
         """Union `other` into this state, in place.
 
+        THE RECEIVER WINS on key collisions, so call this on the FRESHER of the two states
+        and pass the staler one. Sets are unioned either way, but per-PR values
+        (successful_prs, task_pr_urls, other_failed_prs) can genuinely differ - a task
+        republished after its first PR was closed has a new URL - and the newer value must
+        survive.
+
         Used when a state push is rejected because the remote moved: rather than
         hard-overwriting a cursor another writer just published, we take the union so no
         processed PR is forgotten.
@@ -229,7 +235,7 @@ class StreamState:
         self.timeout_prs |= other.timeout_prs
         self.git_error_prs |= other.git_error_prs
 
-        # Ours wins on key collision: this run has the more recent outcome.
+        # Receiver wins on key collision; callers pass the staler state as `other`.
         self.successful_prs = {**other.successful_prs, **self.successful_prs}
         self.task_pr_urls = {**other.task_pr_urls, **self.task_pr_urls}
         self.other_failed_prs = {**other.other_failed_prs, **self.other_failed_prs}

--- a/src/swegen/farm/stream_farm.py
+++ b/src/swegen/farm/stream_farm.py
@@ -247,8 +247,14 @@ class StreamFarmer:
             f"+{pr.additions}/-{pr.deletions}[/dim]"
         )
 
+        # A PR left pending by an earlier publish failure already has a validated task on
+        # disk. Republish it instead of regenerating - force=True would delete it first.
+        publish_only = pr.number in self.state.publish_failed_prs
+
         # Process this PR completely before moving to next
-        result = _run_reversal_for_pr(pr, self.config, self.tasks_root, self.console)
+        result = _run_reversal_for_pr(
+            pr, self.config, self.tasks_root, self.console, publish_only=publish_only
+        )
         self.results.append(result)
 
         # Mark as processed with detailed tracking

--- a/src/swegen/farm/stream_farm.py
+++ b/src/swegen/farm/stream_farm.py
@@ -29,6 +29,19 @@ from .state import StreamState
 
 DOCKER_CLEANUP_CMD = "docker system prune -af"
 
+# Failure categories where the PR was rejected by a cheap filter, before the
+# Claude Code session ran. These paths make only a couple of GitHub API calls and
+# never touch the Anthropic API, so there is nothing to rate limit against and the
+# inter-task delay is pure dead time.
+SKIPPED_CATEGORIES = frozenset(
+    {
+        "trivial",
+        "no_issue",
+        "no_tests",
+        "already_exists",
+    }
+)
+
 
 class StreamFarmer:
     """Manages continuous PR farming with streaming.
@@ -237,9 +250,16 @@ class StreamFarmer:
         # Show result
         self._print_result(result)
 
-        # Rate limit protection: sleep between PRs
-        self.console.print(f"[dim]Waiting {self.config.task_delay} seconds before next PR...[/dim]")
-        time.sleep(self.config.task_delay)
+        # Rate limit protection: only sleep after PRs that actually ran a CC session
+        if not self._should_delay_after(result):
+            self.console.print(
+                f"[dim]Skipping delay ({result.category or result.status}, no CC session run)[/dim]"
+            )
+        elif self.config.task_delay > 0:
+            self.console.print(
+                f"[dim]Waiting {self.config.task_delay} seconds before next PR...[/dim]"
+            )
+            time.sleep(self.config.task_delay)
 
         # Periodic summary
         if self.state.total_processed % 10 == 0:
@@ -249,6 +269,17 @@ class StreamFarmer:
         if self.config.docker_prune_batch > 0:
             if self.state.total_processed % self.config.docker_prune_batch == 0:
                 self._prune_docker()
+
+    def _should_delay_after(self, result: TaskResult) -> bool:
+        """Whether to sleep before the next PR.
+
+        Only PRs that reached the Claude Code session need the delay. Dry runs and
+        PRs rejected by a cheap filter (trivial, no linked issue, no tests, already
+        exists) did no meaningful API work, so waiting on them is dead time.
+        """
+        if result.status == "dry-run":
+            return False
+        return result.category not in SKIPPED_CATEGORIES
 
     def _print_result(self, result: TaskResult) -> None:
         """Print the result of processing a PR.

--- a/src/swegen/farm/stream_farm.py
+++ b/src/swegen/farm/stream_farm.py
@@ -27,7 +27,29 @@ from .farm_hand import (
 from .fetcher import StreamingPRFetcher, load_skip_list
 from .state import StreamState
 
-DOCKER_CLEANUP_CMD = "docker system prune -af"
+# Harbor names every task image "hb__{environment_name}" (see harbor's docker
+# environment). Matching that prefix lets us reclaim the per-task images -- which are
+# the ones that actually consume disk -- without touching base images (ubuntu, language
+# runtimes) or any unrelated image on the host, both of which `docker system prune -af`
+# would happily delete.
+HARBOR_IMAGE_GLOB = "hb__*"
+
+
+def docker_cleanup_cmds(build_cache_keep: str) -> list[str]:
+    """Docker cleanup steps, in order.
+
+    Containers are pruned before images so image removal is not blocked by stopped
+    trial containers. The build cache is trimmed to a ceiling rather than emptied:
+    layers are evicted least-recently-used first, so the base + runtime layers shared
+    by every task survive and rebuilds stay warm, while the per-task layers (whose
+    cache keys embed the task's head SHA, so they are never hit again) are reclaimed.
+    """
+    return [
+        "docker container prune -f",
+        f'docker image ls --filter "reference={HARBOR_IMAGE_GLOB}" -q | xargs -r docker rmi -f',
+        "docker volume prune -f",
+        f"docker builder prune -f --keep-storage {build_cache_keep}",
+    ]
 
 # Failure categories where the PR was rejected by a cheap filter, before the
 # Claude Code session ran. These paths make only a couple of GitHub API calls and
@@ -333,43 +355,48 @@ class StreamFarmer:
             )
             return
 
+        cmds = docker_cleanup_cmds(self.config.build_cache_keep)
         self.console.print(
             Panel(
-                f"Running docker cleanup: {DOCKER_CLEANUP_CMD}",
+                "Running docker cleanup:\n" + "\n".join(f"  {cmd}" for cmd in cmds),
                 title="Disk cleanup",
                 border_style="yellow",
             )
         )
 
-        try:
-            result = subprocess.run(
-                DOCKER_CLEANUP_CMD,
-                shell=True,
-                capture_output=True,
-                text=True,
-                timeout=600,
-            )
-            if result.returncode == 0:
-                stdout = result.stdout.strip()
-                if stdout:
-                    # Show summary if available
-                    lines = stdout.split("\n")
-                    summary_lines = [
-                        line
-                        for line in lines
-                        if "reclaimed" in line.lower()
-                        or "deleted" in line.lower()
-                        or "total" in line.lower()
-                    ]
-                    if summary_lines:
-                        self.console.print(f"[dim]{summary_lines[0]}[/dim]")
-                self.console.print("[green]Docker cleanup completed[/green]")
-            else:
-                self.console.print(f"[red]Docker cleanup failed (exit {result.returncode})[/red]")
+        for cmd in cmds:
+            try:
+                result = subprocess.run(
+                    cmd,
+                    shell=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=600,
+                )
+            except subprocess.TimeoutExpired:
+                self.console.print(f"[red]Docker cleanup timed out after 600s: {cmd}[/red]")
+                continue
+
+            if result.returncode != 0:
+                # Keep going: a failed step (e.g. an image still in use) should not
+                # prevent the remaining steps from reclaiming what they can.
+                self.console.print(
+                    f"[red]Docker cleanup step failed (exit {result.returncode}): {cmd}[/red]"
+                )
                 if result.stderr:
                     self.console.print(f"[red]{result.stderr.strip()}[/red]")
-        except subprocess.TimeoutExpired:
-            self.console.print("[red]Docker prune timed out after 600s[/red]")
+                continue
+
+            # Show the reclaimed-space summary when docker reports one.
+            summary_lines = [
+                line
+                for line in result.stdout.strip().split("\n")
+                if "reclaimed" in line.lower() or "total" in line.lower()
+            ]
+            if summary_lines:
+                self.console.print(f"[dim]{summary_lines[0]}[/dim]")
+
+        self.console.print("[green]Docker cleanup completed[/green]")
 
     def _save_state(self) -> None:
         """Save state to file."""

--- a/src/swegen/farm/stream_farm.py
+++ b/src/swegen/farm/stream_farm.py
@@ -266,7 +266,11 @@ class StreamFarmer:
         self.prs_seen += 1
 
         # Mark as processed with detailed tracking
-        if result.category == "publish_failed":
+        if result.category == "rate_limited":
+            # Do NOT consume the PR. Claude hit a rate/usage limit - nothing was generated,
+            # and a re-run with a fresh token must still farm this PR. The run aborts below.
+            pass
+        elif result.category == "publish_failed":
             # Do NOT consume the PR. The task is valid and only publishing failed, so the
             # next run must retry it rather than skip it. That retry is publish-only (see
             # publish_only above): publishing is idempotent, so it finds the branch this
@@ -355,20 +359,28 @@ class StreamFarmer:
         )
 
     def _check_publish_health(self, result: TaskResult, state_saved: bool) -> bool:
-        """Stop the run on a publish failure or a failed state push. True = stop farming.
+        """Stop the run on a fatal condition. True = stop farming.
 
-        Both are checked together because they can fail in the same iteration - a broken
-        GitHub breaks the task push and the state push alike - and the operator needs to
-        hear about both. No retry-and-continue: a rejected push cannot be distinguished
-        from a broken remote, and continuing would spend a full Claude Code session per PR
-        only to fail at the same wall. Stopping loudly is what lets an operator reach a
-        Daytona sandbox and recover the task before it is reclaimed.
+        Fatal: a publish failure, a failed state push, or a Claude rate/usage limit. Each
+        will recur on the next PR - a broken remote, or an exhausted token - so continuing
+        would spend a full Claude Code session per PR only to fail at the same wall.
+        Publish and state-push are checked together because a broken GitHub hits both in one
+        iteration and the operator needs to hear about both. Stopping loudly is what lets an
+        operator reach a Daytona sandbox before it is reclaimed.
         """
+        rate_limited = result.category == "rate_limited"
         publish_failed = result.category == "publish_failed"
-        if not publish_failed and state_saved:
+        if not rate_limited and not publish_failed and state_saved:
             return False
 
-        if publish_failed:
+        if rate_limited:
+            reason = result.message
+            detail = (
+                "Every task draws from the same limit, so this will not clear until the "
+                "token or account is swapped. Re-run with a fresh token.\n"
+                f"PR #{result.pr_number} was left unprocessed, so it will be farmed then."
+            )
+        elif publish_failed:
             reason = result.message
             detail = (
                 f"The task passed every validation gate and was left in "

--- a/src/swegen/farm/stream_farm.py
+++ b/src/swegen/farm/stream_farm.py
@@ -268,8 +268,11 @@ class StreamFarmer:
         # Mark as processed with detailed tracking
         if result.category == "rate_limited":
             # Do NOT consume the PR. Claude hit a rate/usage limit - nothing was generated,
-            # and a re-run with a fresh token must still farm this PR. The run aborts below.
-            pass
+            # and a re-run with a fresh token must still farm this PR. Record it (not just
+            # skip) so the fetcher exempts it from the resume-time skip; otherwise a PR
+            # sharing the cursor's exact created_at would be dropped and never retried.
+            # The run aborts below.
+            self.state.mark_claude_rate_limited(pr.number)
         elif result.category == "publish_failed":
             # Do NOT consume the PR. The task is valid and only publishing failed, so the
             # next run must retry it rather than skip it. That retry is publish-only (see
@@ -566,6 +569,10 @@ class StreamFarmer:
                 table.add_row("  Git Errors", str(len(self.state.git_error_prs)))
             if self.state.publish_failed_prs:
                 table.add_row("  Publish Failed", str(len(self.state.publish_failed_prs)))
+            if self.state.claude_rate_limited_prs:
+                table.add_row(
+                    "  Claude Rate-Limited", str(len(self.state.claude_rate_limited_prs))
+                )
             if self.state.other_failed_prs:
                 table.add_row("  Other Errors", str(len(self.state.other_failed_prs)))
 

--- a/src/swegen/farm/stream_farm.py
+++ b/src/swegen/farm/stream_farm.py
@@ -16,7 +16,7 @@ from rich.table import Table
 from rich.text import Text
 
 from swegen.config import FarmConfig
-from swegen.publish import build_state_store, build_task_sink
+from swegen.publish import PublishError, build_state_store, build_task_sink
 
 from .farm_hand import (
     PRCandidate,
@@ -86,6 +86,15 @@ class StreamFarmer:
         if config.reset:
             self.state = StreamState(repo=repo)
             self.console.print("[yellow]State reset - starting fresh[/yellow]")
+            if config.publish is not None:
+                # --reset means "start from the beginning", and it does. But with a remote
+                # state branch that discards a cursor shared across sandboxes, not just a
+                # local file: every PR recorded there will be regenerated from scratch.
+                self.console.print(
+                    f"[bold yellow]WARNING: --reset will overwrite the durable state "
+                    f"branch {self.state_store.branch} on {config.publish.repo} at the "
+                    f"first save. Previously processed PRs will be regenerated.[/bold yellow]"
+                )
         else:
             self.state = self.state_store.load(repo)
 
@@ -243,16 +252,22 @@ class StreamFarmer:
         self.results.append(result)
 
         # Mark as processed with detailed tracking
-        self.state.mark_processed(
-            pr.number,
-            pr.created_at,
-            result.status == "success",
-            task_id=result.task_id if result.status == "success" else None,
-            category=result.category,
-            message=result.message if result.category == "other" else None,
-            pr_url=result.pr_url,
-        )
-        self._save_state()
+        if result.category == "publish_failed":
+            # Do NOT consume the PR. The task is valid and only publishing failed, so the
+            # next run must retry it rather than skip it. Publishing is idempotent: it
+            # finds the stale branch, recommits, and opens the PR that never got created.
+            self.state.mark_publish_failed(pr.number)
+        else:
+            self.state.mark_processed(
+                pr.number,
+                pr.created_at,
+                result.status == "success",
+                task_id=result.task_id if result.status == "success" else None,
+                category=result.category,
+                message=result.message if result.category == "other" else None,
+                pr_url=result.pr_url,
+            )
+        state_saved = self._save_state()
 
         # Show result
         self._print_result(result)
@@ -260,6 +275,16 @@ class StreamFarmer:
         # Any publish failure ends the run: every further PR would cost a full Claude
         # Code session and then fail at the same wall.
         if self._check_publish_health(result):
+            return
+
+        # A state push that fails is equally fatal: without a durable cursor a resumed
+        # sandbox would redo every PR from here.
+        if not state_saved:
+            self._abort(
+                "Farm state could not be pushed to the state branch. Continuing would "
+                "leave the durable cursor stale, so a resumed sandbox would regenerate "
+                "every PR processed from this point on."
+            )
             return
 
         # Rate limit protection: sleep between PRs
@@ -275,6 +300,21 @@ class StreamFarmer:
             if self.state.total_processed % self.config.docker_prune_batch == 0:
                 self._prune_docker()
 
+    def _abort(self, reason: str, detail: str = "") -> None:
+        """Stop the run loudly, so an operator can reach the sandbox before reclamation."""
+        self.aborted = True
+        self.shutdown_requested = True
+        body = reason
+        if detail:
+            body += f"\n\n{detail}"
+        body += (
+            "\n\nFix the token or GitHub connectivity, then re-run. Farm state is "
+            "preserved, so already-processed PRs will not be regenerated."
+        )
+        self.console.print(
+            Panel(Text(body, style="red"), title="[red]Stopping[/red]", border_style="red")
+        )
+
     def _check_publish_health(self, result: TaskResult) -> bool:
         """Stop the run on any publish failure. Returns True if farming should stop.
 
@@ -286,22 +326,12 @@ class StreamFarmer:
         if result.category != "publish_failed":
             return False
 
-        self.aborted = True
-        self.shutdown_requested = True
-        self.console.print(
-            Panel(
-                Text(
-                    f"{result.message}\n\n"
-                    f"The task passed every validation gate and was left in "
-                    f"{self.tasks_root}/{result.task_id} - it can be pushed by hand.\n"
-                    f"On an ephemeral sandbox, recover it before the sandbox is reclaimed.\n\n"
-                    f"Fix the token or GitHub connectivity, then re-run - farm state is "
-                    f"preserved, so processed PRs will not be regenerated.",
-                    style="red",
-                ),
-                title="[red]Stopping: could not publish task[/red]",
-                border_style="red",
-            )
+        self._abort(
+            result.message,
+            f"The task passed every validation gate and was left in "
+            f"{self.tasks_root}/{result.task_id} - it can be pushed by hand.\n"
+            f"On an ephemeral sandbox, recover it before the sandbox is reclaimed.\n"
+            f"PR #{result.pr_number} was left unprocessed, so a re-run will retry it.",
         )
         return True
 
@@ -403,14 +433,23 @@ class StreamFarmer:
         except subprocess.TimeoutExpired:
             self.console.print("[red]Docker prune timed out after 600s[/red]")
 
-    def _save_state(self) -> None:
-        """Persist state via the configured store.
+    def _save_state(self) -> bool:
+        """Persist state via the configured store. Returns False if it could not be saved.
 
         With publishing enabled this pushes to the state branch, so a sandbox killed
         mid-run resumes from the last completed PR. _finalize() runs from a finally
         block, which means a Daytona SIGTERM flushes state before exit.
+
+        A failure here is as serious as a failed task publish: if the state branch stops
+        advancing, a resumed sandbox redoes work it already paid for. The caller stops
+        the run. The local mirror is still written, so nothing is lost from disk.
         """
-        self.state_store.save(self.state)
+        try:
+            self.state_store.save(self.state)
+            return True
+        except PublishError as e:
+            self.console.print(f"[red]Could not persist farm state: {e}[/red]")
+            return False
 
     def _finalize(self) -> None:
         """Finalize the run and print summary."""

--- a/src/swegen/farm/stream_farm.py
+++ b/src/swegen/farm/stream_farm.py
@@ -268,8 +268,9 @@ class StreamFarmer:
         # Mark as processed with detailed tracking
         if result.category == "publish_failed":
             # Do NOT consume the PR. The task is valid and only publishing failed, so the
-            # next run must retry it rather than skip it. Publishing is idempotent: it
-            # finds the stale branch, recommits, and opens the PR that never got created.
+            # next run must retry it rather than skip it. That retry is publish-only (see
+            # publish_only above): publishing is idempotent, so it finds the branch this
+            # task left behind, refreshes it, and opens the PR that never got created.
             self.state.mark_publish_failed(pr.number)
         elif result.status == "dry-run":
             # --dry-run generates nothing. Recording the PR would consume it AND file it

--- a/src/swegen/farm/stream_farm.py
+++ b/src/swegen/farm/stream_farm.py
@@ -16,6 +16,7 @@ from rich.table import Table
 from rich.text import Text
 
 from swegen.config import FarmConfig
+from swegen.publish import build_state_store, build_task_sink
 
 from .farm_hand import (
     PRCandidate,
@@ -62,17 +63,31 @@ class StreamFarmer:
         self.config = config
         self.console = console
         self.tasks_root = config.output
-        self.tasks_root.mkdir(exist_ok=True)
+        self.tasks_root.mkdir(parents=True, exist_ok=True)
 
-        # State file path
+        # State file path (also the local mirror when publishing)
         self.state_file = config.state_dir / "stream_farm" / f"{_slug(repo)}.json"
+
+        # Preflight the sink before any PR is processed: a bad token must fail in
+        # seconds, not after the first hour-long Claude Code session.
+        self.sink = build_task_sink(config.publish, repo, state_dir=config.state_dir)
+        if config.publish is not None:
+            self.console.print(
+                f"[cyan]Publishing tasks to {config.publish.repo} "
+                f"(base: {config.publish.base_branch})[/cyan]"
+            )
+            self.sink.preflight()
+
+        self.state_store = build_state_store(
+            config.publish, repo, self.state_file, state_dir=config.state_dir
+        )
 
         # Load or create state
         if config.reset:
             self.state = StreamState(repo=repo)
             self.console.print("[yellow]State reset - starting fresh[/yellow]")
         else:
-            self.state = StreamState.load(self.state_file, repo)
+            self.state = self.state_store.load(repo)
 
         # Load skip list if provided
         if config.skip_list:
@@ -102,6 +117,7 @@ class StreamFarmer:
 
         # Graceful shutdown handling
         self.shutdown_requested = False
+        self.aborted = False
         signal.signal(signal.SIGINT, self._handle_shutdown)
         signal.signal(signal.SIGTERM, self._handle_shutdown)
 
@@ -157,7 +173,8 @@ class StreamFarmer:
         """Run the continuous farming process.
 
         Returns:
-            Exit code: 0 if any tasks succeeded, 1 otherwise
+            Exit code: 0 if any tasks succeeded, 1 otherwise. Aborting because publishing
+            broke is always a failure, even if earlier tasks published fine.
         """
         self._print_header()
 
@@ -169,6 +186,8 @@ class StreamFarmer:
         finally:
             self._finalize()
 
+        if self.aborted:
+            return 1
         return 0 if self.state.successful > 0 else 1
 
     def _print_header(self) -> None:
@@ -225,17 +244,23 @@ class StreamFarmer:
 
         # Mark as processed with detailed tracking
         self.state.mark_processed(
-            pr.number, 
-            pr.created_at, 
+            pr.number,
+            pr.created_at,
             result.status == "success",
             task_id=result.task_id if result.status == "success" else None,
             category=result.category,
             message=result.message if result.category == "other" else None,
+            pr_url=result.pr_url,
         )
         self._save_state()
 
         # Show result
         self._print_result(result)
+
+        # Any publish failure ends the run: every further PR would cost a full Claude
+        # Code session and then fail at the same wall.
+        if self._check_publish_health(result):
+            return
 
         # Rate limit protection: sleep between PRs
         self.console.print(f"[dim]Waiting {self.config.task_delay} seconds before next PR...[/dim]")
@@ -250,6 +275,36 @@ class StreamFarmer:
             if self.state.total_processed % self.config.docker_prune_batch == 0:
                 self._prune_docker()
 
+    def _check_publish_health(self, result: TaskResult) -> bool:
+        """Stop the run on any publish failure. Returns True if farming should stop.
+
+        No retry-and-continue: a rejected push cannot be distinguished from a broken
+        remote, and continuing would spend a full Claude Code session per PR only to
+        fail at the same wall. Stopping loudly is what lets an operator reach a Daytona
+        sandbox and recover the task before it is reclaimed.
+        """
+        if result.category != "publish_failed":
+            return False
+
+        self.aborted = True
+        self.shutdown_requested = True
+        self.console.print(
+            Panel(
+                Text(
+                    f"{result.message}\n\n"
+                    f"The task passed every validation gate and was left in "
+                    f"{self.tasks_root}/{result.task_id} - it can be pushed by hand.\n"
+                    f"On an ephemeral sandbox, recover it before the sandbox is reclaimed.\n\n"
+                    f"Fix the token or GitHub connectivity, then re-run - farm state is "
+                    f"preserved, so processed PRs will not be regenerated.",
+                    style="red",
+                ),
+                title="[red]Stopping: could not publish task[/red]",
+                border_style="red",
+            )
+        )
+        return True
+
     def _print_result(self, result: TaskResult) -> None:
         """Print the result of processing a PR.
 
@@ -258,6 +313,8 @@ class StreamFarmer:
         """
         if result.status == "success":
             self.console.print(f"[green]✓ Success: {result.message}[/green]")
+            if result.pr_url:
+                self.console.print(f"[green]  PR: {result.pr_url}[/green]")
         elif result.status == "dry-run":
             self.console.print(f"[cyan]○ Dry-run: {result.message}[/cyan]")
         else:
@@ -295,7 +352,13 @@ class StreamFarmer:
         )
 
     def _prune_docker(self) -> None:
-        """Run docker cleanup to free disk space."""
+        """Run docker cleanup to free disk space.
+
+        WARNING: `docker system prune -af` is global to the daemon. Two farm processes
+        sharing a host will destroy each other's images and build cache mid-validation.
+        One container per repo is the intended deployment; if you colocate farms, pass
+        --docker-prune-batch 0 to all but one.
+        """
         if shutil.which("docker") is None:
             self.console.print(
                 "[yellow]Skipping docker prune (docker binary not found in PATH).[/yellow]"
@@ -341,8 +404,13 @@ class StreamFarmer:
             self.console.print("[red]Docker prune timed out after 600s[/red]")
 
     def _save_state(self) -> None:
-        """Save state to file."""
-        self.state.save(self.state_file)
+        """Persist state via the configured store.
+
+        With publishing enabled this pushes to the state branch, so a sandbox killed
+        mid-run resumes from the last completed PR. _finalize() runs from a finally
+        block, which means a Daytona SIGTERM flushes state before exit.
+        """
+        self.state_store.save(self.state)
 
     def _finalize(self) -> None:
         """Finalize the run and print summary."""
@@ -383,6 +451,8 @@ class StreamFarmer:
                 table.add_row("  Timeouts", str(len(self.state.timeout_prs)))
             if self.state.git_error_prs:
                 table.add_row("  Git Errors", str(len(self.state.git_error_prs)))
+            if self.state.publish_failed_prs:
+                table.add_row("  Publish Failed", str(len(self.state.publish_failed_prs)))
             if self.state.other_failed_prs:
                 table.add_row("  Other Errors", str(len(self.state.other_failed_prs)))
 

--- a/src/swegen/farm/stream_farm.py
+++ b/src/swegen/farm/stream_farm.py
@@ -272,19 +272,10 @@ class StreamFarmer:
         # Show result
         self._print_result(result)
 
-        # Any publish failure ends the run: every further PR would cost a full Claude
-        # Code session and then fail at the same wall.
-        if self._check_publish_health(result):
-            return
-
-        # A state push that fails is equally fatal: without a durable cursor a resumed
-        # sandbox would redo every PR from here.
-        if not state_saved:
-            self._abort(
-                "Farm state could not be pushed to the state branch. Continuing would "
-                "leave the durable cursor stale, so a resumed sandbox would regenerate "
-                "every PR processed from this point on."
-            )
+        # A publish failure or a failed state push ends the run. Checked together: both can
+        # fail in the same iteration, and reporting only the first would tell the operator
+        # farm state was preserved when it was not.
+        if self._check_publish_health(result, state_saved):
             return
 
         # Rate limit protection: sleep between PRs
@@ -300,39 +291,66 @@ class StreamFarmer:
             if self.state.total_processed % self.config.docker_prune_batch == 0:
                 self._prune_docker()
 
-    def _abort(self, reason: str, detail: str = "") -> None:
-        """Stop the run loudly, so an operator can reach the sandbox before reclamation."""
+    def _abort(self, reason: str, detail: str = "", state_saved: bool = True) -> None:
+        """Stop the run loudly, so an operator can reach the sandbox before reclamation.
+
+        `state_saved` must reflect whether the durable state branch actually advanced. A
+        publish failure and a state-push failure can happen in the same iteration, and
+        telling the operator that state was preserved when it was not sends them into the
+        next run expecting a resume that will not happen.
+        """
         self.aborted = True
         self.shutdown_requested = True
         body = reason
         if detail:
             body += f"\n\n{detail}"
-        body += (
-            "\n\nFix the token or GitHub connectivity, then re-run. Farm state is "
-            "preserved, so already-processed PRs will not be regenerated."
-        )
+
+        if state_saved:
+            body += (
+                "\n\nFix the token or GitHub connectivity, then re-run. Farm state is "
+                "preserved, so already-processed PRs will not be regenerated."
+            )
+        else:
+            body += (
+                "\n\nThe durable state branch was NOT updated: this run's progress exists "
+                f"only in the local mirror ({self.state_file}). Recover it before this "
+                "sandbox is reclaimed, or a re-run will regenerate the PRs processed here."
+            )
+
         self.console.print(
             Panel(Text(body, style="red"), title="[red]Stopping[/red]", border_style="red")
         )
 
-    def _check_publish_health(self, result: TaskResult) -> bool:
-        """Stop the run on any publish failure. Returns True if farming should stop.
+    def _check_publish_health(self, result: TaskResult, state_saved: bool) -> bool:
+        """Stop the run on a publish failure or a failed state push. True = stop farming.
 
-        No retry-and-continue: a rejected push cannot be distinguished from a broken
-        remote, and continuing would spend a full Claude Code session per PR only to
-        fail at the same wall. Stopping loudly is what lets an operator reach a Daytona
-        sandbox and recover the task before it is reclaimed.
+        Both are checked together because they can fail in the same iteration - a broken
+        GitHub breaks the task push and the state push alike - and the operator needs to
+        hear about both. No retry-and-continue: a rejected push cannot be distinguished
+        from a broken remote, and continuing would spend a full Claude Code session per PR
+        only to fail at the same wall. Stopping loudly is what lets an operator reach a
+        Daytona sandbox and recover the task before it is reclaimed.
         """
-        if result.category != "publish_failed":
+        publish_failed = result.category == "publish_failed"
+        if not publish_failed and state_saved:
             return False
 
-        self._abort(
-            result.message,
-            f"The task passed every validation gate and was left in "
-            f"{self.tasks_root}/{result.task_id} - it can be pushed by hand.\n"
-            f"On an ephemeral sandbox, recover it before the sandbox is reclaimed.\n"
-            f"PR #{result.pr_number} was left unprocessed, so a re-run will retry it.",
-        )
+        if publish_failed:
+            reason = result.message
+            detail = (
+                f"The task passed every validation gate and was left in "
+                f"{self.tasks_root}/{result.task_id} - it can be pushed by hand.\n"
+                f"On an ephemeral sandbox, recover it before the sandbox is reclaimed.\n"
+                f"PR #{result.pr_number} was left unprocessed, so a re-run will retry it."
+            )
+        else:
+            reason = "Farm state could not be pushed to the state branch."
+            detail = (
+                "Continuing would leave the durable cursor stale, so a resumed sandbox "
+                "would regenerate every PR processed from this point on."
+            )
+
+        self._abort(reason, detail, state_saved=state_saved)
         return True
 
     def _print_result(self, result: TaskResult) -> None:

--- a/src/swegen/farm/stream_farm.py
+++ b/src/swegen/farm/stream_farm.py
@@ -127,6 +127,12 @@ class StreamFarmer:
         # Graceful shutdown handling
         self.shutdown_requested = False
         self.aborted = False
+
+        # PRs handled this run. Distinct from state.total_processed, which counts PRs
+        # *consumed* - a dry run and a pending publish deliberately consume nothing, and
+        # driving the prune/progress cadence off a counter that never moves would fire
+        # them on every iteration.
+        self.prs_seen = 0
         signal.signal(signal.SIGINT, self._handle_shutdown)
         signal.signal(signal.SIGTERM, self._handle_shutdown)
 
@@ -238,7 +244,7 @@ class StreamFarmer:
         # Print PR header
         merged_dt = datetime.fromisoformat(pr.merged_at.replace("Z", "+00:00"))
         self.console.print(
-            f"\n[bold cyan]═══ PR #{pr.number} ({self.state.total_processed + 1}) ═══[/bold cyan]"
+            f"\n[bold cyan]═══ PR #{pr.number} ({self.prs_seen + 1}) ═══[/bold cyan]"
         )
         self.console.print(f"[bold]{pr.title}[/bold]")
         self.console.print(
@@ -257,12 +263,19 @@ class StreamFarmer:
         )
         self.results.append(result)
 
+        self.prs_seen += 1
+
         # Mark as processed with detailed tracking
         if result.category == "publish_failed":
             # Do NOT consume the PR. The task is valid and only publishing failed, so the
             # next run must retry it rather than skip it. Publishing is idempotent: it
             # finds the stale branch, recommits, and opens the PR that never got created.
             self.state.mark_publish_failed(pr.number)
+        elif result.status == "dry-run":
+            # --dry-run generates nothing. Recording the PR would consume it AND file it
+            # under other_failed_prs as "Unknown error" (success=False, category=None),
+            # so a later real run would skip a PR that was never farmed.
+            pass
         elif result.status == "success" and self._publish_is_dry_run():
             # Also do NOT consume the PR. The task was generated and validated but nothing
             # reached the dataset repo, so a later real run must still farm this PR. The
@@ -296,13 +309,14 @@ class StreamFarmer:
         self.console.print(f"[dim]Waiting {self.config.task_delay} seconds before next PR...[/dim]")
         time.sleep(self.config.task_delay)
 
-        # Periodic summary
-        if self.state.total_processed % 10 == 0:
+        # Periodic summary. Driven by PRs seen this run, not PRs consumed: dry runs and
+        # pending publishes consume nothing, and `0 % n == 0` would fire every iteration.
+        if self.prs_seen % 10 == 0:
             self._print_progress()
 
         # Docker cleanup after batch
         if self.config.docker_prune_batch > 0:
-            if self.state.total_processed % self.config.docker_prune_batch == 0:
+            if self.prs_seen % self.config.docker_prune_batch == 0:
                 self._prune_docker()
 
     def _publish_is_dry_run(self) -> bool:

--- a/src/swegen/farm/stream_farm.py
+++ b/src/swegen/farm/stream_farm.py
@@ -257,6 +257,14 @@ class StreamFarmer:
             # next run must retry it rather than skip it. Publishing is idempotent: it
             # finds the stale branch, recommits, and opens the PR that never got created.
             self.state.mark_publish_failed(pr.number)
+        elif result.status == "success" and self._publish_is_dry_run():
+            # Also do NOT consume the PR. The task was generated and validated but nothing
+            # reached the dataset repo, so a later real run must still farm this PR. The
+            # local mirror persists, and without this a dry run would silently poison it.
+            self.console.print(
+                f"[cyan]DRY RUN: task built but not published; leaving PR #{pr.number} "
+                f"unprocessed so a real run will farm it[/cyan]"
+            )
         else:
             self.state.mark_processed(
                 pr.number,
@@ -290,6 +298,10 @@ class StreamFarmer:
         if self.config.docker_prune_batch > 0:
             if self.state.total_processed % self.config.docker_prune_batch == 0:
                 self._prune_docker()
+
+    def _publish_is_dry_run(self) -> bool:
+        """True when publishing is configured but pushes and PR creation are suppressed."""
+        return self.config.publish is not None and self.config.publish.dry_run
 
     def _abort(self, reason: str, detail: str = "", state_saved: bool = True) -> None:
         """Stop the run loudly, so an operator can reach the sandbox before reclamation.

--- a/src/swegen/farm/stream_farm.py
+++ b/src/swegen/farm/stream_farm.py
@@ -452,8 +452,19 @@ class StreamFarmer:
             return False
 
     def _finalize(self) -> None:
-        """Finalize the run and print summary."""
-        self._save_state()
+        """Finalize the run and print summary.
+
+        Runs from a finally block, so a Daytona SIGTERM flushes state before exit. A final
+        state push that fails is recorded as an abort: the durable cursor is now behind the
+        work actually done, and a resumed sandbox would redo it. Exiting 0 would tell a
+        supervisor everything was fine.
+        """
+        if not self._save_state():
+            self.aborted = True
+            self.console.print(
+                "[red]Final state push failed - the durable cursor is stale. "
+                "Recover the local state mirror before this sandbox is reclaimed.[/red]"
+            )
         self._save_log()
 
         self.console.print("\n")

--- a/src/swegen/farm/stream_farm.py
+++ b/src/swegen/farm/stream_farm.py
@@ -79,7 +79,7 @@ class StreamFarmer:
             self.sink.preflight()
 
         self.state_store = build_state_store(
-            config.publish, repo, self.state_file, state_dir=config.state_dir
+            config.publish, repo, self.state_file, state_dir=config.state_dir, reset=config.reset
         )
 
         # Load or create state

--- a/src/swegen/publish/__init__.py
+++ b/src/swegen/publish/__init__.py
@@ -37,11 +37,13 @@ def build_state_store(
     source_repo: str,
     local_state_file: Path,
     state_dir: Path = Path(".swegen"),
+    reset: bool = False,
 ) -> StateStore:
     """Return the state store for `source_repo`.
 
     With publishing enabled, state is committed to a branch on the dataset repo and
-    also mirrored locally for debugging.
+    also mirrored locally for debugging. `reset` signals that the durable state branch
+    should be overwritten rather than merged on the first save (see GitStateStore).
     """
     from .git_state import GitStateStore
     from .local_state import LocalStateStore
@@ -51,6 +53,7 @@ def build_state_store(
     return GitStateStore(
         publish,
         source_repo,
+        reset=reset,
         clone_dir=default_clone_dir(publish, source_repo, state_dir),
         local_mirror=local_state_file,
     )

--- a/src/swegen/publish/__init__.py
+++ b/src/swegen/publish/__init__.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from swegen.config import PublishConfig
+
+from .base import (
+    PublishAuthError,
+    PublishContext,
+    PublishError,
+    PublishResult,
+    StateStore,
+    TaskSink,
+)
+from .git_ops import GitError, GitRepo, slug
+from .github_pr import GitHubPRSink, default_clone_dir
+from .null import NullSink
+
+# NOTE: git_state/local_state are imported lazily inside build_state_store. They import
+# swegen.farm.state, whose package __init__ pulls in StreamFarmer, which imports this
+# module - importing them at module scope would be a circular import.
+
+
+def build_task_sink(
+    publish: PublishConfig | None,
+    source_repo: str,
+    state_dir: Path = Path(".swegen"),
+) -> TaskSink:
+    """Return the sink for `source_repo`. NullSink when publishing is disabled."""
+    if publish is None:
+        return NullSink()
+    return GitHubPRSink(publish, source_repo, state_dir=state_dir)
+
+
+def build_state_store(
+    publish: PublishConfig | None,
+    source_repo: str,
+    local_state_file: Path,
+    state_dir: Path = Path(".swegen"),
+) -> StateStore:
+    """Return the state store for `source_repo`.
+
+    With publishing enabled, state is committed to a branch on the dataset repo and
+    also mirrored locally for debugging.
+    """
+    from .git_state import GitStateStore
+    from .local_state import LocalStateStore
+
+    if publish is None:
+        return LocalStateStore(local_state_file)
+    return GitStateStore(
+        publish,
+        source_repo,
+        clone_dir=default_clone_dir(publish, source_repo, state_dir),
+        local_mirror=local_state_file,
+    )
+
+
+__all__ = [
+    "GitError",
+    "GitHubPRSink",
+    "GitRepo",
+    "NullSink",
+    "PublishAuthError",
+    "PublishContext",
+    "PublishError",
+    "PublishResult",
+    "StateStore",
+    "TaskSink",
+    "build_state_store",
+    "build_task_sink",
+    "default_clone_dir",
+    "slug",
+]

--- a/src/swegen/publish/base.py
+++ b/src/swegen/publish/base.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+
+class PublishError(RuntimeError):
+    """A task was generated and validated but could not be published.
+
+    Always ends the farm run. Continuing would spend a full Claude Code session on the
+    next PR only to fail at the same wall, and a task that exists solely on an ephemeral
+    sandbox is one reclaim away from being lost. The task directory is preserved so an
+    operator can recover it by hand.
+    """
+
+
+class PublishAuthError(PublishError):
+    """The publish token is missing, invalid, or lacks write access.
+
+    Never retried - retrying would hammer a rejecting endpoint. Raised at preflight,
+    before any PR is processed.
+    """
+
+
+@dataclass(frozen=True)
+class PublishContext:
+    """Everything a sink needs to publish one generated task."""
+
+    task_id: str
+    task_dir: Path
+    source_repo: str
+    source_pr: int
+    source_pr_url: str
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PublishResult:
+    """Outcome of publishing one task."""
+
+    published: bool
+    pr_url: str | None = None
+    branch: str | None = None
+
+
+class TaskSink(Protocol):
+    """Destination for generated tasks.
+
+    Implementations must be idempotent: publishing a task that was already published
+    returns the existing result rather than raising, so a restarted sandbox that
+    regenerates a task does not fail on it.
+    """
+
+    def preflight(self) -> None:
+        """Verify the destination is reachable and writable. Raises PublishAuthError."""
+        ...
+
+    def publish(self, ctx: PublishContext) -> PublishResult:
+        """Publish one task. Raises PublishError on unrecoverable failure."""
+        ...
+
+
+class StateStore(Protocol):
+    """Persistence backend for farm state."""
+
+    def load(self, repo: str):
+        """Load StreamState for `repo`, or a fresh one if absent."""
+        ...
+
+    def save(self, state) -> None:
+        """Persist StreamState. Must be safe to call after every PR."""
+        ...

--- a/src/swegen/publish/base.py
+++ b/src/swegen/publish/base.py
@@ -6,12 +6,16 @@ from typing import Protocol
 
 
 class PublishError(RuntimeError):
-    """A task was generated and validated but could not be published.
+    """A task could not be published.
+
+    Usually the task was generated and validated and only the push or PR creation failed;
+    it is also raised when a task recorded in state is missing from disk.
 
     Always ends the farm run. Continuing would spend a full Claude Code session on the
     next PR only to fail at the same wall, and a task that exists solely on an ephemeral
-    sandbox is one reclaim away from being lost. The task directory is preserved so an
-    operator can recover it by hand.
+    sandbox is one reclaim away from being lost. Where the task directory exists it is
+    preserved - never cleaned up - so an operator can publish it by hand, and a re-run
+    retries the publish without regenerating it.
     """
 
 

--- a/src/swegen/publish/body.py
+++ b/src/swegen/publish/body.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from .base import PublishContext
+
+PR_TITLE_TEMPLATE = "Add task: {task_id}"
+
+PR_BODY_TEMPLATE = """Generated from `{source_repo}`#{source_pr}
+
+{source_pr_url}
+"""
+
+
+def render_pr_title(ctx: PublishContext) -> str:
+    return PR_TITLE_TEMPLATE.format(task_id=ctx.task_id)
+
+
+def render_pr_body(ctx: PublishContext) -> str:
+    """Render the PR description.
+
+    Deliberately minimal. Extra detail (difficulty, tags, validation rewards) is
+    available on ctx.metadata and can be folded into the template here without the
+    sink needing to change.
+    """
+    return PR_BODY_TEMPLATE.format(
+        source_repo=ctx.source_repo,
+        source_pr=ctx.source_pr,
+        source_pr_url=ctx.source_pr_url,
+    )
+
+
+def render_commit_message(ctx: PublishContext) -> str:
+    return f"Add task: {ctx.task_id}"

--- a/src/swegen/publish/gh_api.py
+++ b/src/swegen/publish/gh_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import time
 from typing import Any
+from urllib.parse import urlencode
 
 import requests
 
@@ -121,8 +122,15 @@ class GitHubAPI:
         return self.request("GET", f"/repos/{repo}")
 
     def find_open_pr(self, repo: str, head_branch: str) -> dict | None:
+        """Find the open PR whose head is `head_branch`, if any.
+
+        The query is percent-encoded: branch names carry a `/` from the branch prefix, and
+        --publish-branch-prefix is user-supplied, so an `&` or `#` in it would otherwise
+        truncate or corrupt the query rather than simply not matching.
+        """
         owner = repo.split("/")[0]
-        prs = self.request("GET", f"/repos/{repo}/pulls?head={owner}:{head_branch}&state=open")
+        query = urlencode({"head": f"{owner}:{head_branch}", "state": "open"})
+        prs = self.request("GET", f"/repos/{repo}/pulls?{query}")
         return prs[0] if prs else None
 
     def create_pr(self, repo: str, title: str, body: str, head: str, base: str) -> dict:

--- a/src/swegen/publish/gh_api.py
+++ b/src/swegen/publish/gh_api.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+import requests
+
+from .base import PublishAuthError, PublishError
+
+API_BASE = "https://api.github.com"
+MAX_ATTEMPTS = 3
+BACKOFF_BASE_SECONDS = 2.0
+MAX_RETRY_AFTER_SECONDS = 60.0
+
+
+class GitHubAPI:
+    """Minimal GitHub REST client for publishing, with bounded retries.
+
+    Uses `requests` directly, matching create/pr_fetcher.py rather than pulling in a
+    second GitHub client style.
+    """
+
+    def __init__(self, token: str) -> None:
+        self.token = token
+        self.logger = logging.getLogger("swegen")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+            }
+        )
+
+    def _sleep_for(self, response: requests.Response, attempt: int) -> float:
+        """Honor Retry-After when GitHub sends it, else exponential backoff."""
+        retry_after = response.headers.get("Retry-After")
+        if retry_after:
+            try:
+                return min(float(retry_after), MAX_RETRY_AFTER_SECONDS)
+            except ValueError:
+                pass
+        return BACKOFF_BASE_SECONDS * (2 ** (attempt - 1))
+
+    def _is_auth_failure(self, response: requests.Response) -> bool:
+        """401 always. 403 only when it is not a rate limit dressed up as a 403."""
+        if response.status_code == 401:
+            return True
+        if response.status_code != 403:
+            return False
+        if response.headers.get("Retry-After"):
+            return False
+        return response.headers.get("X-RateLimit-Remaining") != "0"
+
+    def request(self, method: str, path: str, json: dict | None = None) -> Any:
+        """Issue a request, retrying transient failures.
+
+        Raises:
+            PublishAuthError: the token is rejected (never retried).
+            PublishError: retries were exhausted (5xx, rate limit, dead connection), or
+                GitHub rejected the request outright (e.g. 422). Either way the caller
+                stops farming; the two are distinguished only in the message.
+        """
+        url = f"{API_BASE}{path}"
+        last_error = ""
+        exhausted_retries = False
+
+        for attempt in range(1, MAX_ATTEMPTS + 1):
+            try:
+                response = self.session.request(method, url, json=json, timeout=30)
+            except requests.RequestException as e:
+                last_error = str(e)
+                if attempt == MAX_ATTEMPTS:
+                    exhausted_retries = True
+                    break
+                time.sleep(BACKOFF_BASE_SECONDS * (2 ** (attempt - 1)))
+                continue
+
+            if response.status_code < 400:
+                return response.json() if response.content else {}
+
+            if self._is_auth_failure(response):
+                raise PublishAuthError(
+                    f"{method} {path} -> {response.status_code}: token is invalid or "
+                    f"lacks write access. {response.text[:200]}"
+                )
+
+            retryable = response.status_code in (429, 500, 502, 503, 504) or (
+                response.status_code == 403 and not self._is_auth_failure(response)
+            )
+            last_error = f"{response.status_code}: {response.text[:200]}"
+            if not retryable:
+                break
+            if attempt == MAX_ATTEMPTS:
+                exhausted_retries = True
+                break
+
+            delay = self._sleep_for(response, attempt)
+            self.logger.warning(
+                "GitHub %s %s -> %s, retrying in %.1fs (attempt %d/%d)",
+                method,
+                path,
+                response.status_code,
+                delay,
+                attempt,
+                MAX_ATTEMPTS,
+            )
+            time.sleep(delay)
+
+        if exhausted_retries:
+            raise PublishError(
+                f"{method} {path} failed after {MAX_ATTEMPTS} attempts: {last_error}. "
+                f"GitHub is unreachable or throttling."
+            )
+        raise PublishError(f"{method} {path} rejected: {last_error}")
+
+    # -- endpoints used by the sink -----------------------------------------
+
+    def get_repo(self, repo: str) -> dict:
+        return self.request("GET", f"/repos/{repo}")
+
+    def find_open_pr(self, repo: str, head_branch: str) -> dict | None:
+        owner = repo.split("/")[0]
+        prs = self.request("GET", f"/repos/{repo}/pulls?head={owner}:{head_branch}&state=open")
+        return prs[0] if prs else None
+
+    def create_pr(self, repo: str, title: str, body: str, head: str, base: str) -> dict:
+        return self.request(
+            "POST",
+            f"/repos/{repo}/pulls",
+            json={"title": title, "body": body, "head": head, "base": base},
+        )

--- a/src/swegen/publish/git_ops.py
+++ b/src/swegen/publish/git_ops.py
@@ -166,7 +166,14 @@ class GitRepo:
         self._run(["commit", "-m", message], cwd=cwd, identity=True)
         return True
 
-    def push(self, refspec: str, *, cwd: Path | None = None, allow_force: bool = False) -> None:
+    def push(
+        self,
+        refspec: str,
+        *,
+        cwd: Path | None = None,
+        allow_force: bool = False,
+        force: bool = False,
+    ) -> None:
         """Push `refspec` to origin.
 
         Tries a normal push first, and only falls back to --force-with-lease when the
@@ -174,7 +181,20 @@ class GitRepo:
         remote and belongs to this one task, either as a leftover from an earlier attempt
         or as the branch backing its open PR, which we cut fresh and refresh. Either way
         we say so in the log.
+
+        `force` is an unconditional `git push --force`, used only to honor an explicit
+        --reset of the durable state branch: the intent is to discard whatever is on the
+        remote, so --force-with-lease (which aborts when the remote moved) is wrong here.
         """
+        if force:
+            self._run(
+                ["push", "--force", "origin", refspec],
+                cwd=cwd,
+                network=True,
+                remote_write=True,
+            )
+            return
+
         proc = self._run(
             ["push", "origin", refspec],
             cwd=cwd,

--- a/src/swegen/publish/git_ops.py
+++ b/src/swegen/publish/git_ops.py
@@ -165,9 +165,11 @@ class GitRepo:
     def push(self, refspec: str, *, cwd: Path | None = None, allow_force: bool = False) -> None:
         """Push `refspec` to origin.
 
-        Tries a normal push first. Only if that is rejected - which for our branch
-        naming means a stale branch left by an earlier run of this same task - do we
-        fall back to --force-with-lease, and we say so.
+        Tries a normal push first, and only falls back to --force-with-lease when the
+        caller passes allow_force - true exactly when the branch already exists on the
+        remote and belongs to this one task, either as a leftover from an earlier attempt
+        or as the branch backing its open PR, which we cut fresh and refresh. Either way
+        we say so in the log.
         """
         proc = self._run(
             ["push", "origin", refspec],

--- a/src/swegen/publish/git_ops.py
+++ b/src/swegen/publish/git_ops.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+from .base import PublishError
+
+
+class GitError(PublishError):
+    """A git command failed."""
+
+
+def slug(repo: str) -> str:
+    """owner/repo -> owner__repo (SWEBench convention, matches farm_hand._slug)."""
+    return repo.replace("/", "__")
+
+
+class GitRepo:
+    """Thin subprocess wrapper around a clone of the dataset repo.
+
+    Only ever drives one clone. Task branches are built in the main working tree;
+    the state branch lives in a linked worktree (see `add_worktree`) so that pushing
+    state after every PR never disturbs a task branch mid-build.
+
+    NOTE: serial use only. StreamFarmer processes one PR at a time, so a single
+    working tree with `checkout -B` per task is safe. Concurrent task generation in
+    one process would need a worktree per task.
+    """
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        token: str | None = None,
+        author_name: str = "",
+        author_email: str = "",
+        dry_run: bool = False,
+    ) -> None:
+        self.path = Path(path)
+        self.token = token
+        self.author_name = author_name
+        self.author_email = author_email
+        self.dry_run = dry_run
+        self.logger = logging.getLogger("swegen")
+
+    # -- command plumbing ----------------------------------------------------
+
+    def _auth_args(self) -> list[str]:
+        """Auth header passed per-invocation so the token never lands in .git/config."""
+        if not self.token:
+            return []
+        basic = base64.b64encode(f"x-access-token:{self.token}".encode()).decode()
+        return ["-c", f"http.extraheader=AUTHORIZATION: basic {basic}"]
+
+    def _identity_args(self) -> list[str]:
+        args = []
+        if self.author_name:
+            args += ["-c", f"user.name={self.author_name}"]
+        if self.author_email:
+            args += ["-c", f"user.email={self.author_email}"]
+        return args
+
+    def _run(
+        self,
+        args: list[str],
+        *,
+        cwd: Path | None = None,
+        network: bool = False,
+        remote_write: bool = False,
+        identity: bool = False,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess:
+        """Run a git command.
+
+        Args:
+            network: prepend the auth header (needed for fetch/clone/push/ls-remote)
+            remote_write: skipped entirely under dry_run (push)
+            identity: pass -c user.name/-c user.email (needed for commit)
+            check: raise GitError on nonzero exit
+        """
+        if remote_write and self.dry_run:
+            self.logger.info("[dry-run] would run: git %s", " ".join(args))
+            return subprocess.CompletedProcess(args, 0, "", "")
+
+        cmd = ["git"]
+        if network:
+            cmd += self._auth_args()
+        if identity:
+            cmd += self._identity_args()
+        cmd += args
+
+        proc = subprocess.run(
+            cmd,
+            cwd=str(cwd or self.path),
+            capture_output=True,
+            text=True,
+            env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+        )
+        if check and proc.returncode != 0:
+            raise GitError(f"git {' '.join(args)} failed: {proc.stderr.strip()}")
+        return proc
+
+    def git(self, *args: str, **kwargs) -> str:
+        """Run a git command and return stripped stdout."""
+        return self._run(list(args), **kwargs).stdout.strip()
+
+    # -- clone / fetch -------------------------------------------------------
+
+    def ensure_clone(self, url: str) -> None:
+        """Clone the repo if absent, otherwise fetch. Idempotent across restarts."""
+        if (self.path / ".git").exists():
+            self.logger.debug("Using existing publish clone: %s", self.path)
+            self._run(["fetch", "origin", "--prune"], network=True)
+            return
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.logger.info("Cloning dataset repo -> %s", self.path)
+        self._run(
+            ["clone", url, str(self.path)],
+            cwd=self.path.parent,
+            network=True,
+        )
+
+    def fetch(self, ref: str) -> None:
+        self._run(["fetch", "origin", ref], network=True)
+
+    def remote_branch_exists(self, branch: str) -> bool:
+        out = self.git("ls-remote", "--heads", "origin", branch, network=True)
+        return bool(out)
+
+    # -- branches / commits --------------------------------------------------
+
+    def checkout_fresh_branch(self, branch: str, base_ref: str) -> None:
+        """Cut `branch` from `base_ref`, discarding any prior state on it.
+
+        Every task branch is cut fresh from origin/<base> so branches never stack on
+        one another and each PR carries a single-task diff.
+        """
+        self._run(["checkout", "-B", branch, base_ref])
+
+    def add(self, pathspec: str, *, cwd: Path | None = None) -> None:
+        """Stage `pathspec`, overriding .gitignore.
+
+        --force is deliberate: SWE-gen's own .gitignore excludes `tasks/` because that is
+        the local output directory, and a dataset repo created from this template inherits
+        it. We are publishing generated tasks on purpose, so an ignore rule in the dataset
+        repo must not silently drop them. Only the one pathspec we name is ever staged.
+        """
+        self._run(["add", "--all", "--force", pathspec], cwd=cwd)
+
+    def has_staged_changes(self, *, cwd: Path | None = None) -> bool:
+        proc = self._run(["diff", "--cached", "--quiet"], cwd=cwd, check=False)
+        return proc.returncode != 0
+
+    def commit(self, message: str, *, cwd: Path | None = None) -> bool:
+        """Commit staged changes. Returns False if there was nothing to commit."""
+        if not self.has_staged_changes(cwd=cwd):
+            return False
+        self._run(["commit", "-m", message], cwd=cwd, identity=True)
+        return True
+
+    def push(self, refspec: str, *, cwd: Path | None = None, allow_force: bool = False) -> None:
+        """Push `refspec` to origin.
+
+        Tries a normal push first. Only if that is rejected - which for our branch
+        naming means a stale branch left by an earlier run of this same task - do we
+        fall back to --force-with-lease, and we say so.
+        """
+        proc = self._run(
+            ["push", "origin", refspec],
+            cwd=cwd,
+            network=True,
+            remote_write=True,
+            check=False,
+        )
+        if proc.returncode == 0:
+            return
+
+        if not allow_force:
+            raise GitError(f"git push origin {refspec} failed: {proc.stderr.strip()}")
+
+        self.logger.warning(
+            "Normal push of %s was rejected (%s). Branch is a stale leftover from an "
+            "earlier attempt at this task; retrying with --force-with-lease.",
+            refspec,
+            proc.stderr.strip().splitlines()[-1] if proc.stderr.strip() else "no stderr",
+        )
+        self._run(
+            ["push", "--force-with-lease", "origin", refspec],
+            cwd=cwd,
+            network=True,
+            remote_write=True,
+        )
+
+    # -- worktrees -----------------------------------------------------------
+
+    def add_worktree(self, wt_path: Path, branch: str, base_ref: str) -> Path:
+        """Check `branch` out into a linked worktree at `wt_path`.
+
+        Creates the branch as an orphan (empty history) if it does not exist on the
+        remote - the state branch shares no history with the task branches and must
+        never be merged into them.
+        """
+        wt_path = Path(wt_path)
+        if (wt_path / ".git").exists():
+            return wt_path
+
+        wt_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if self.remote_branch_exists(branch):
+            self.fetch(branch)
+            self._run(["worktree", "add", "-B", branch, str(wt_path), f"origin/{branch}"])
+            return wt_path
+
+        # Orphan branch. `git worktree add --orphan` needs git >= 2.42, so build it
+        # the portable way: detach onto base, then orphan the checkout and empty it.
+        self._run(["worktree", "add", "--detach", str(wt_path), base_ref])
+        self._run(["checkout", "--orphan", branch], cwd=wt_path)
+        self._run(["rm", "-rf", "--quiet", "."], cwd=wt_path, check=False)
+        return wt_path

--- a/src/swegen/publish/git_ops.py
+++ b/src/swegen/publish/git_ops.py
@@ -39,7 +39,11 @@ class GitRepo:
         author_email: str = "",
         dry_run: bool = False,
     ) -> None:
-        self.path = Path(path)
+        # Absolute, always. `ensure_clone` runs `git clone <url> <path>` from the parent
+        # directory, so a relative path (the default state dir is `.swegen`) would be
+        # resolved against that cwd and the clone would land one level nested. Every other
+        # method then chdirs into a path that does not exist.
+        self.path = Path(path).resolve()
         self.token = token
         self.author_name = author_name
         self.author_email = author_email

--- a/src/swegen/publish/git_ops.py
+++ b/src/swegen/publish/git_ops.py
@@ -183,8 +183,9 @@ class GitRepo:
             raise GitError(f"git push origin {refspec} failed: {proc.stderr.strip()}")
 
         self.logger.warning(
-            "Normal push of %s was rejected (%s). Branch is a stale leftover from an "
-            "earlier attempt at this task; retrying with --force-with-lease.",
+            "Normal push of %s was rejected (%s). The branch belongs to this task alone - "
+            "a leftover from an earlier attempt, or the branch backing its open PR - so "
+            "retrying with --force-with-lease.",
             refspec,
             proc.stderr.strip().splitlines()[-1] if proc.stderr.strip() else "no stderr",
         )

--- a/src/swegen/publish/git_state.py
+++ b/src/swegen/publish/git_state.py
@@ -105,23 +105,30 @@ class GitStateStore:
         """
         self._ensure_worktree()
 
-        state = self._read_state_file(repo)
+        remote = self._read_state_file(repo)
         local = self._read_local_mirror(repo)
 
-        if state is None:
+        if remote is None:
             if local is None:
                 self.logger.info("No usable published state for %s; starting fresh", repo)
                 return StreamState(repo=repo)
             self.logger.info("No published state for %s; resuming from local mirror", repo)
             return local
 
-        if local is not None:
-            before = len(state.processed_prs)
-            state.merge_from(local)
+        if local is None:
+            state = remote
+        else:
+            # Merge INTO the mirror, not into the remote. The mirror is written before every
+            # push, so after a failed push it holds the newer per-PR values (a task_pr_url
+            # from a task republished under a new PR, say). merge_from lets the receiver win
+            # on collisions, so the fresher side must be the receiver.
+            before = len(local.processed_prs)
+            local.merge_from(remote)
+            state = local
             recovered = len(state.processed_prs) - before
-            if recovered or local.publish_failed_prs:
+            if recovered or state.publish_failed_prs:
                 self.logger.info(
-                    "Local mirror was ahead of the state branch: recovered %d processed PRs, "
+                    "Merged local mirror with the state branch: %d PRs only on the branch, "
                     "%d pending publish failures",
                     recovered,
                     len(state.publish_failed_prs),

--- a/src/swegen/publish/git_state.py
+++ b/src/swegen/publish/git_state.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from swegen.config import PublishConfig
 from swegen.farm.state import StreamState
 
+from .base import PublishError
 from .git_ops import GitRepo, slug
 
 
@@ -95,11 +96,15 @@ class GitStateStore:
         return state
 
     def save(self, state: StreamState) -> None:
-        """Commit and push state.
+        """Commit and push state. Raises PublishError if it cannot be published.
 
-        Non-fatal: a failed state push is retried on the next PR and again from
-        _finalize(), so one transient failure should not abort a farm run. It is logged
-        at warning level because silently losing state would cost hours of rework.
+        Not swallowed: if the state branch stops advancing, a reclaimed sandbox resumes
+        from a stale cursor and repeats hours of Claude Code work on PRs already handled.
+        That is exactly the failure this class exists to prevent, so the caller stops the
+        run instead of farming blind.
+
+        The local mirror is written first, so state survives on disk even when the push
+        fails and can be recovered from the sandbox before it is reclaimed.
         """
         if self.local_mirror is not None:
             state.save(self.local_mirror)
@@ -107,8 +112,10 @@ class GitStateStore:
         try:
             self._ensure_worktree()
             self._write_and_push(state)
+        except PublishError:
+            raise
         except Exception as e:
-            self.logger.warning("Could not publish farm state to %s: %s", self.branch, e)
+            raise PublishError(f"Could not publish farm state to {self.branch}: {e}") from e
 
     def _write_and_push(self, state: StreamState) -> None:
         rel_path = f"{self.cfg.state_path}/{slug(self.source_repo)}.json"

--- a/src/swegen/publish/git_state.py
+++ b/src/swegen/publish/git_state.py
@@ -38,7 +38,9 @@ class GitStateStore:
     ) -> None:
         self.cfg = cfg
         self.source_repo = source_repo
-        self.clone_dir = Path(clone_dir)
+        # Resolved: the linked worktree path is derived from this, and git runs with cwd
+        # set to both. The default state dir is relative.
+        self.clone_dir = Path(clone_dir).resolve()
         self.local_mirror = local_mirror
         self.logger = logging.getLogger("swegen")
         self.git = git or GitRepo(

--- a/src/swegen/publish/git_state.py
+++ b/src/swegen/publish/git_state.py
@@ -114,12 +114,17 @@ class GitStateStore:
         return StreamState.from_dict(data)
 
     def load(self, repo: str) -> StreamState:
-        """Resume from the published state, folding in any fresher local mirror.
+        """Resume from the published state, merged with any local mirror.
 
-        The mirror is written before every push, so if a push failed the mirror is ahead
-        of the branch. Reading only the remote would forget those PRs - they would be
-        regenerated - and would drop publish_failed_prs, which the fetcher needs to know
-        that a PR is still awaiting its PR. Merging is a union, so neither source loses.
+        The mirror is written before every push, so after a failed push it is ahead of the
+        branch. But the branch can equally be ahead: another sandbox may have advanced it
+        while this one's .swegen sat on a persistent volume. Reading only one side would
+        forget the other's PRs and drop publish_failed_prs, which the fetcher needs to know
+        a PR is still awaiting its PR.
+
+        Sets are unioned whichever way the merge runs, so no PR is ever lost. The receiver
+        only decides per-PR value collisions (task_pr_urls, successful_prs,
+        other_failed_prs), so it must be whichever side was written more recently.
         """
         self._ensure_worktree()
 
@@ -136,21 +141,25 @@ class GitStateStore:
         if local is None:
             state = remote
         else:
-            # Merge INTO the mirror, not into the remote. The mirror is written before every
-            # push, so after a failed push it holds the newer per-PR values (a task_pr_url
-            # from a task republished under a new PR, say). merge_from lets the receiver win
-            # on collisions, so the fresher side must be the receiver.
-            before = len(local.processed_prs)
-            local.merge_from(remote)
-            state = local
+            # merge_from gives the receiver precedence, so the fresher side receives. Ties
+            # favour the mirror: it is written immediately before the push that produces the
+            # branch commit, so equal timestamps mean equal content, and preferring it keeps
+            # the failed-push recovery - the reason the mirror exists - working.
+            local_is_fresher = (local.last_updated or "") >= (remote.last_updated or "")
+            fresher, staler = (local, remote) if local_is_fresher else (remote, local)
+            source = "local mirror" if local_is_fresher else "state branch"
+
+            before = len(fresher.processed_prs)
+            fresher.merge_from(staler)
+            state = fresher
             recovered = len(state.processed_prs) - before
-            if recovered or state.publish_failed_prs:
-                self.logger.info(
-                    "Merged local mirror with the state branch: %d PRs only on the branch, "
-                    "%d pending publish failures",
-                    recovered,
-                    len(state.publish_failed_prs),
-                )
+            self.logger.info(
+                "Merged local mirror with the state branch (%s is newer): recovered %d PRs "
+                "from the other side, %d pending publish failures",
+                source,
+                recovered,
+                len(state.publish_failed_prs),
+            )
 
         self.logger.info(
             "Resumed published state for %s: %d PRs processed, %d tasks published",

--- a/src/swegen/publish/git_state.py
+++ b/src/swegen/publish/git_state.py
@@ -61,7 +61,25 @@ class GitStateStore:
             return
         self.git.ensure_clone(f"https://github.com/{self.cfg.repo}.git")
         self.git.add_worktree(self.worktree, self.branch, f"origin/{self.cfg.base_branch}")
+        self._sync_worktree()
         self._ready = True
+
+    def _sync_worktree(self) -> None:
+        """Fast-forward the state worktree onto the remote branch.
+
+        add_worktree() returns an existing worktree untouched, so a clone left over from an
+        earlier run holds whatever snapshot it was last on. Reading that would resume from a
+        stale cursor and silently drop processed_prs and publish_failed_prs recorded by a
+        later run - exactly what the state branch exists to prevent.
+
+        A hard reset is safe: the worktree only ever holds the state JSON, which is
+        regenerated from the in-memory state on every save, and anything not yet pushed also
+        lives in the local mirror.
+        """
+        if not self.git.remote_branch_exists(self.branch):
+            return
+        self.git.fetch(self.branch)
+        self.git.git("reset", "--hard", f"origin/{self.branch}", cwd=self.worktree)
 
     # -- StateStore protocol -------------------------------------------------
 

--- a/src/swegen/publish/git_state.py
+++ b/src/swegen/publish/git_state.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from swegen.config import PublishConfig
+from swegen.farm.state import StreamState
+
+from .git_ops import GitRepo, slug
+
+
+class GitStateStore:
+    """Farm state committed to a per-source-repo branch on the dataset repo.
+
+    This is what lets an ephemeral sandbox resume: without it a fresh container
+    restarts from the newest PR and re-burns Claude Code and OpenAI calls on every PR
+    it previously rejected, which is most of them.
+
+    The branch is `<state_branch_prefix><source_slug>` (e.g. farm-state/fastapi__fastapi).
+    Per-source-repo naming means N containers farming N repos never contend. The branch
+    is orphaned and never merged, and lives in a linked worktree so state pushes do not
+    disturb the task branch checked out in the main tree.
+
+    Git refs are a directory namespace: `farm-state/fastapi__fastapi` cannot coexist with
+    a bare `farm-state` branch. Only the prefixed form is ever created.
+    """
+
+    def __init__(
+        self,
+        cfg: PublishConfig,
+        source_repo: str,
+        clone_dir: Path,
+        *,
+        git: GitRepo | None = None,
+        local_mirror: Path | None = None,
+    ) -> None:
+        self.cfg = cfg
+        self.source_repo = source_repo
+        self.clone_dir = Path(clone_dir)
+        self.local_mirror = local_mirror
+        self.logger = logging.getLogger("swegen")
+        self.git = git or GitRepo(
+            self.clone_dir,
+            token=cfg.token,
+            author_name=cfg.author_name,
+            author_email=cfg.author_email,
+            dry_run=cfg.dry_run,
+        )
+        self.branch = f"{cfg.state_branch_prefix}{slug(source_repo)}"
+        self.worktree = self.clone_dir.parent / f"{self.clone_dir.name}-state"
+        self._ready = False
+
+    @property
+    def state_file(self) -> Path:
+        return self.worktree / self.cfg.state_path / f"{slug(self.source_repo)}.json"
+
+    def _ensure_worktree(self) -> None:
+        if self._ready:
+            return
+        self.git.ensure_clone(f"https://github.com/{self.cfg.repo}.git")
+        self.git.add_worktree(self.worktree, self.branch, f"origin/{self.cfg.base_branch}")
+        self._ready = True
+
+    # -- StateStore protocol -------------------------------------------------
+
+    def load(self, repo: str) -> StreamState:
+        self._ensure_worktree()
+
+        if not self.state_file.exists():
+            self.logger.info("No published state for %s; starting fresh", repo)
+            return StreamState(repo=repo)
+
+        try:
+            data = json.loads(self.state_file.read_text())
+        except (OSError, ValueError) as e:
+            self.logger.warning(
+                "Published state for %s is unreadable (%s); starting fresh", repo, e
+            )
+            return StreamState(repo=repo)
+
+        if data.get("repo") != repo:
+            self.logger.warning(
+                "Published state is for %s, not %s; starting fresh", data.get("repo"), repo
+            )
+            return StreamState(repo=repo)
+
+        state = StreamState.from_dict(data)
+        self.logger.info(
+            "Resumed published state for %s: %d PRs processed, %d tasks published",
+            repo,
+            state.total_processed,
+            state.successful,
+        )
+        return state
+
+    def save(self, state: StreamState) -> None:
+        """Commit and push state.
+
+        Non-fatal: a failed state push is retried on the next PR and again from
+        _finalize(), so one transient failure should not abort a farm run. It is logged
+        at warning level because silently losing state would cost hours of rework.
+        """
+        if self.local_mirror is not None:
+            state.save(self.local_mirror)
+
+        try:
+            self._ensure_worktree()
+            self._write_and_push(state)
+        except Exception as e:
+            self.logger.warning("Could not publish farm state to %s: %s", self.branch, e)
+
+    def _write_and_push(self, state: StreamState) -> None:
+        rel_path = f"{self.cfg.state_path}/{slug(self.source_repo)}.json"
+        refspec = f"{self.branch}:refs/heads/{self.branch}"
+
+        self._commit_state(state, rel_path)
+        try:
+            self.git.push(refspec, cwd=self.worktree)
+            return
+        except Exception as e:
+            self.logger.warning("State push rejected (%s); rebasing onto remote and retrying", e)
+
+        # The remote moved under us. Our state is a full snapshot, so reset onto the
+        # remote tip and re-apply it as an additive commit rather than force-pushing.
+        self.git.git("fetch", "origin", self.branch, cwd=self.worktree, network=True)
+        self.git.git("reset", "--hard", f"origin/{self.branch}", cwd=self.worktree)
+        self._commit_state(state, rel_path)
+        self.git.push(refspec, cwd=self.worktree)
+
+    def _commit_state(self, state: StreamState, rel_path: str) -> None:
+        self.state_file.parent.mkdir(parents=True, exist_ok=True)
+        self.state_file.write_text(json.dumps(state.to_dict(), indent=2))
+        self.git.add(rel_path, cwd=self.worktree)
+        self.git.commit(
+            f"Update farm state: {self.source_repo} (PR #{state.last_pr_number})",
+            cwd=self.worktree,
+        )

--- a/src/swegen/publish/git_state.py
+++ b/src/swegen/publish/git_state.py
@@ -82,13 +82,50 @@ class GitStateStore:
 
         return StreamState.from_dict(data)
 
+    def _read_local_mirror(self, repo: str) -> StreamState | None:
+        """Parse the local mirror, or None if absent/unusable."""
+        if self.local_mirror is None or not Path(self.local_mirror).exists():
+            return None
+        try:
+            data = json.loads(Path(self.local_mirror).read_text())
+        except (OSError, ValueError) as e:
+            self.logger.warning("Local state mirror is unreadable (%s); ignoring", e)
+            return None
+        if data.get("repo") != repo:
+            return None
+        return StreamState.from_dict(data)
+
     def load(self, repo: str) -> StreamState:
+        """Resume from the published state, folding in any fresher local mirror.
+
+        The mirror is written before every push, so if a push failed the mirror is ahead
+        of the branch. Reading only the remote would forget those PRs - they would be
+        regenerated - and would drop publish_failed_prs, which the fetcher needs to know
+        that a PR is still awaiting its PR. Merging is a union, so neither source loses.
+        """
         self._ensure_worktree()
 
         state = self._read_state_file(repo)
+        local = self._read_local_mirror(repo)
+
         if state is None:
-            self.logger.info("No usable published state for %s; starting fresh", repo)
-            return StreamState(repo=repo)
+            if local is None:
+                self.logger.info("No usable published state for %s; starting fresh", repo)
+                return StreamState(repo=repo)
+            self.logger.info("No published state for %s; resuming from local mirror", repo)
+            return local
+
+        if local is not None:
+            before = len(state.processed_prs)
+            state.merge_from(local)
+            recovered = len(state.processed_prs) - before
+            if recovered or local.publish_failed_prs:
+                self.logger.info(
+                    "Local mirror was ahead of the state branch: recovered %d processed PRs, "
+                    "%d pending publish failures",
+                    recovered,
+                    len(state.publish_failed_prs),
+                )
 
         self.logger.info(
             "Resumed published state for %s: %d PRs processed, %d tasks published",
@@ -129,6 +166,11 @@ class GitStateStore:
             self.git.push(refspec, cwd=self.worktree)
             return
         except Exception as e:
+            # The merge recovery below only makes sense if the remote branch exists. When
+            # it does not, the push failed for some other reason (network, auth, hook) and
+            # `fetch origin <branch>` would fail too, masking the real error.
+            if not self.git.remote_branch_exists(self.branch):
+                raise
             self.logger.warning("State push rejected (%s); merging with remote and retrying", e)
 
         # The remote moved under us. Reset onto the remote tip, then MERGE the remote's

--- a/src/swegen/publish/git_state.py
+++ b/src/swegen/publish/git_state.py
@@ -65,28 +65,31 @@ class GitStateStore:
 
     # -- StateStore protocol -------------------------------------------------
 
-    def load(self, repo: str) -> StreamState:
-        self._ensure_worktree()
-
+    def _read_state_file(self, repo: str) -> StreamState | None:
+        """Parse the state file in the worktree, or None if absent/unusable."""
         if not self.state_file.exists():
-            self.logger.info("No published state for %s; starting fresh", repo)
-            return StreamState(repo=repo)
+            return None
 
         try:
             data = json.loads(self.state_file.read_text())
         except (OSError, ValueError) as e:
-            self.logger.warning(
-                "Published state for %s is unreadable (%s); starting fresh", repo, e
-            )
-            return StreamState(repo=repo)
+            self.logger.warning("Published state for %s is unreadable (%s)", repo, e)
+            return None
 
         if data.get("repo") != repo:
-            self.logger.warning(
-                "Published state is for %s, not %s; starting fresh", data.get("repo"), repo
-            )
+            self.logger.warning("Published state is for %s, not %s", data.get("repo"), repo)
+            return None
+
+        return StreamState.from_dict(data)
+
+    def load(self, repo: str) -> StreamState:
+        self._ensure_worktree()
+
+        state = self._read_state_file(repo)
+        if state is None:
+            self.logger.info("No usable published state for %s; starting fresh", repo)
             return StreamState(repo=repo)
 
-        state = StreamState.from_dict(data)
         self.logger.info(
             "Resumed published state for %s: %d PRs processed, %d tasks published",
             repo,
@@ -126,12 +129,19 @@ class GitStateStore:
             self.git.push(refspec, cwd=self.worktree)
             return
         except Exception as e:
-            self.logger.warning("State push rejected (%s); rebasing onto remote and retrying", e)
+            self.logger.warning("State push rejected (%s); merging with remote and retrying", e)
 
-        # The remote moved under us. Our state is a full snapshot, so reset onto the
-        # remote tip and re-apply it as an additive commit rather than force-pushing.
+        # The remote moved under us. Reset onto the remote tip, then MERGE the remote's
+        # state into ours before recommitting. Blindly recommitting our in-memory snapshot
+        # would discard whatever cursor the other writer just published, losing PRs it had
+        # already processed. Merging is a union, so neither side forgets work.
         self.git.git("fetch", "origin", self.branch, cwd=self.worktree, network=True)
         self.git.git("reset", "--hard", f"origin/{self.branch}", cwd=self.worktree)
+
+        remote_state = self._read_state_file(state.repo)
+        if remote_state is not None:
+            state.merge_from(remote_state)
+
         self._commit_state(state, rel_path)
         self.git.push(refspec, cwd=self.worktree)
 

--- a/src/swegen/publish/git_state.py
+++ b/src/swegen/publish/git_state.py
@@ -240,6 +240,13 @@ class GitStateStore:
         remote_state = self._read_state_file(state.repo)
         if remote_state is not None:
             state.merge_from(remote_state)
+            # merge_from mutated the in-memory state; refresh the mirror so it reflects what
+            # we are about to push. save() wrote the mirror once before the merge, and the
+            # recovery guidance points operators at it - a stale pre-merge mirror would
+            # disagree with the branch. (load() unions the two anyway, so this is
+            # consistency, not data safety.)
+            if self.local_mirror is not None:
+                state.save(self.local_mirror)
 
         self._commit_state(state, rel_path)
         self.git.push(refspec, cwd=self.worktree)

--- a/src/swegen/publish/git_state.py
+++ b/src/swegen/publish/git_state.py
@@ -35,9 +35,14 @@ class GitStateStore:
         *,
         git: GitRepo | None = None,
         local_mirror: Path | None = None,
+        reset: bool = False,
     ) -> None:
         self.cfg = cfg
         self.source_repo = source_repo
+        # --reset: the first push must OVERWRITE the durable branch. Cleared once applied,
+        # so later saves in the same run merge normally with any legitimate concurrent
+        # writer rather than force-clobbering forever.
+        self._pending_reset = reset
         # Resolved: the linked worktree path is derived from this, and git runs with cwd
         # set to both. The default state dir is relative.
         self.clone_dir = Path(clone_dir).resolve()
@@ -200,6 +205,7 @@ class GitStateStore:
         self._commit_state(state, rel_path)
         try:
             self.git.push(refspec, cwd=self.worktree)
+            self._pending_reset = False
             return
         except Exception as e:
             # The merge recovery below only makes sense if the remote branch exists. When
@@ -207,6 +213,21 @@ class GitStateStore:
             # `fetch origin <branch>` would fail too, masking the real error.
             if not self.git.remote_branch_exists(self.branch):
                 raise
+
+            if self._pending_reset:
+                # --reset means "discard the durable state". Merging the remote back in
+                # would silently undo the reset, so overwrite the branch instead. Only the
+                # first save of a reset run forces; after that we merge normally so a
+                # legitimate concurrent writer is not clobbered on every subsequent PR.
+                self.logger.warning(
+                    "State push rejected (%s); --reset in effect, overwriting %s",
+                    e,
+                    self.branch,
+                )
+                self.git.push(refspec, cwd=self.worktree, force=True)
+                self._pending_reset = False
+                return
+
             self.logger.warning("State push rejected (%s); merging with remote and retrying", e)
 
         # The remote moved under us. Reset onto the remote tip, then MERGE the remote's

--- a/src/swegen/publish/github_pr.py
+++ b/src/swegen/publish/github_pr.py
@@ -41,7 +41,9 @@ class GitHubPRSink:
     ) -> None:
         self.cfg = cfg
         self.source_repo = source_repo
-        self.clone_dir = default_clone_dir(cfg, source_repo, state_dir)
+        # Resolved: git commands run with cwd set to this directory, and the default
+        # state dir is relative.
+        self.clone_dir = default_clone_dir(cfg, source_repo, state_dir).resolve()
         self.logger = logging.getLogger("swegen")
         self.api = GitHubAPI(cfg.token)
         self.git = git or GitRepo(

--- a/src/swegen/publish/github_pr.py
+++ b/src/swegen/publish/github_pr.py
@@ -86,6 +86,13 @@ class GitHubPRSink:
     # -- publish -------------------------------------------------------------
 
     def publish(self, ctx: PublishContext) -> PublishResult:
+        """Publish `ctx` to its own branch, opening a PR if one is not already open.
+
+        An existing open PR short-circuits only PR *creation*, never the branch update.
+        The caller may have regenerated the task (--force, --reset, a rerun after a failed
+        create.jsonl write), and returning early would leave the branch and PR on older
+        content while the pipeline reported success.
+        """
         self.preflight()
 
         branch = self.branch_for(ctx.task_id)
@@ -94,9 +101,10 @@ class GitHubPRSink:
         existing = None if self.cfg.dry_run else self.api.find_open_pr(self.cfg.repo, branch)
         if existing:
             self.logger.info(
-                "Task %s already has an open PR: %s", ctx.task_id, existing["html_url"]
+                "Task %s already has an open PR (%s); refreshing its branch",
+                ctx.task_id,
+                existing["html_url"],
             )
-            return PublishResult(published=True, pr_url=existing["html_url"], branch=branch)
 
         stale_branch = self.git.remote_branch_exists(branch)
 
@@ -112,12 +120,21 @@ class GitHubPRSink:
         rel_path = f"{self.cfg.tasks_path}/{ctx.task_id}"
         self.git.add(rel_path)
         if not self.git.commit(render_commit_message(ctx)):
-            raise PublishError(
-                f"Nothing to commit for {ctx.task_id}; task directory {ctx.task_dir} may be empty."
+            # The branch is cut from the base, so an empty diff means the task is already
+            # merged there byte-for-byte. Nothing to push, and no PR to open.
+            if not any(dest.iterdir()):
+                raise PublishError(f"Task directory {ctx.task_dir} is empty; nothing to publish.")
+            self.logger.info(
+                "Task %s is already present in %s; nothing to publish",
+                ctx.task_id,
+                self.cfg.base_branch,
             )
+            pr_url = existing["html_url"] if existing else None
+            return PublishResult(published=True, pr_url=pr_url, branch=branch)
 
-        # A stale branch is one this same task left behind on an earlier attempt, so
-        # overwriting it is safe. A fresh branch must never need force.
+        # A stale branch belongs to this same task from an earlier attempt (or backs the
+        # open PR we are refreshing), so overwriting it is safe. A fresh branch never
+        # needs force.
         self.git.push(f"{branch}:refs/heads/{branch}", allow_force=stale_branch)
 
         if self.cfg.dry_run:
@@ -129,6 +146,10 @@ class GitHubPRSink:
                 self.cfg.base_branch,
             )
             return PublishResult(published=False, pr_url=None, branch=branch)
+
+        if existing:
+            # Branch refreshed above; the open PR now carries the regenerated task.
+            return PublishResult(published=True, pr_url=existing["html_url"], branch=branch)
 
         pr = self.api.create_pr(
             repo=self.cfg.repo,

--- a/src/swegen/publish/github_pr.py
+++ b/src/swegen/publish/github_pr.py
@@ -63,20 +63,35 @@ class GitHubPRSink:
         return f"{self.cfg.branch_prefix}{task_id}"
 
     def preflight(self) -> None:
-        """Verify write access and prepare the clone, before any task is generated.
+        """Verify the dataset repo is reachable and writable, before any task is generated.
 
-        Called once at farm startup so a bad token fails in seconds rather than after
-        the first hour-long Claude Code session.
+        Called once at farm startup so a bad token fails in seconds rather than after the
+        first hour-long Claude Code session.
+
+        Only an EXPLICIT `push: false` is treated as a rejection. Some tokens - notably
+        fine-grained PATs and app installation tokens - omit or under-report `permissions`
+        on GET /repos, and refusing those would block a token whose pushes and PRs would
+        have succeeded. When the field is absent we warn and let the first push decide:
+        a publish failure aborts the run and preserves the task, so the cost of being
+        wrong is one Claude Code session, not a lost task.
         """
         if self._preflight_done:
             return
 
         repo_data = self.api.get_repo(self.cfg.repo)
-        permissions = repo_data.get("permissions") or {}
-        if not permissions.get("push"):
-            raise PublishAuthError(
-                f"Token lacks write access to {self.cfg.repo}. Needs a fine-grained PAT "
-                f"with contents:write and pull_requests:write (or classic 'repo' scope)."
+        permissions = repo_data.get("permissions")
+
+        if isinstance(permissions, dict) and "push" in permissions:
+            if not permissions["push"]:
+                raise PublishAuthError(
+                    f"Token lacks write access to {self.cfg.repo}. Needs a fine-grained PAT "
+                    f"with contents:write and pull_requests:write (or classic 'repo' scope)."
+                )
+        else:
+            self.logger.warning(
+                "GitHub did not report push permission for %s (common for fine-grained and "
+                "app tokens). Proceeding; a write failure will surface on the first publish.",
+                self.cfg.repo,
             )
 
         self.git.ensure_clone(self.clone_url)

--- a/src/swegen/publish/github_pr.py
+++ b/src/swegen/publish/github_pr.py
@@ -129,20 +129,36 @@ class GitHubPRSink:
         self.git.checkout_fresh_branch(branch, f"origin/{self.cfg.base_branch}")
 
         dest = self.clone_dir / self.cfg.tasks_path / ctx.task_id
-        if dest.exists():
-            shutil.rmtree(dest)
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(ctx.task_dir, dest)
+        # Filesystem errors here (disk full, permissions) must surface as PublishError, not
+        # a bare OSError. A bare OSError reads to the farm as a generic pipeline failure,
+        # which cleans up (deletes) the validated task - but this is a publish failure, and
+        # the task must be kept on disk for a re-run. git ops already raise GitError
+        # (a PublishError); only these copies were unguarded.
+        try:
+            if dest.exists():
+                shutil.rmtree(dest)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(ctx.task_dir, dest)
+        except OSError as e:
+            raise PublishError(
+                f"Could not stage task {ctx.task_id} into the clone ({dest}): {e}"
+            ) from e
 
         rel_path = f"{self.cfg.tasks_path}/{ctx.task_id}"
         self.git.add(rel_path)
         if not self.git.commit(render_commit_message(ctx)):
             # The branch is cut from the base, so an empty diff means the task is already
-            # merged there byte-for-byte. Nothing to push, and no PR to open.
+            # merged there byte-for-byte. There is no new commit to push.
             if not any(dest.iterdir()):
                 raise PublishError(f"Task directory {ctx.task_dir} is empty; nothing to publish.")
+            # A stale remote branch (and any open PR on it) can still point at an older
+            # commit. Our branch now equals base, so force it up: the branch reflects that
+            # the task is in base, rather than leaving the PR showing outdated content while
+            # we report published=True.
+            if stale_branch:
+                self.git.push(f"{branch}:refs/heads/{branch}", allow_force=True)
             self.logger.info(
-                "Task %s is already present in %s; nothing to publish",
+                "Task %s is already present in %s; branch synced, nothing new to publish",
                 ctx.task_id,
                 self.cfg.base_branch,
             )

--- a/src/swegen/publish/github_pr.py
+++ b/src/swegen/publish/github_pr.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+
+from swegen.config import PublishConfig
+
+from .base import PublishAuthError, PublishContext, PublishError, PublishResult
+from .body import render_commit_message, render_pr_body, render_pr_title
+from .gh_api import GitHubAPI
+from .git_ops import GitRepo, slug
+
+
+def default_clone_dir(cfg: PublishConfig, source_repo: str, state_dir: Path) -> Path:
+    """Where to clone the dataset repo.
+
+    Keyed by *both* dataset and source repo: the dataset repo is the same across all
+    containers, so keying only on it would make two farms colocated on one host fight
+    over a single working tree.
+    """
+    if cfg.clone_dir is not None:
+        return Path(cfg.clone_dir)
+    return state_dir / "publish" / slug(cfg.repo) / slug(source_repo)
+
+
+class GitHubPRSink:
+    """Publishes each validated task as its own branch + pull request.
+
+    Shares one clone with GitStateStore; the state branch lives in a linked worktree,
+    so state pushes never disturb the task branch checked out in the main tree.
+    """
+
+    def __init__(
+        self,
+        cfg: PublishConfig,
+        source_repo: str,
+        *,
+        state_dir: Path = Path(".swegen"),
+        git: GitRepo | None = None,
+    ) -> None:
+        self.cfg = cfg
+        self.source_repo = source_repo
+        self.clone_dir = default_clone_dir(cfg, source_repo, state_dir)
+        self.logger = logging.getLogger("swegen")
+        self.api = GitHubAPI(cfg.token)
+        self.git = git or GitRepo(
+            self.clone_dir,
+            token=cfg.token,
+            author_name=cfg.author_name,
+            author_email=cfg.author_email,
+            dry_run=cfg.dry_run,
+        )
+        self._preflight_done = False
+
+    # -- lifecycle -----------------------------------------------------------
+
+    @property
+    def clone_url(self) -> str:
+        return f"https://github.com/{self.cfg.repo}.git"
+
+    def branch_for(self, task_id: str) -> str:
+        return f"{self.cfg.branch_prefix}{task_id}"
+
+    def preflight(self) -> None:
+        """Verify write access and prepare the clone, before any task is generated.
+
+        Called once at farm startup so a bad token fails in seconds rather than after
+        the first hour-long Claude Code session.
+        """
+        if self._preflight_done:
+            return
+
+        repo_data = self.api.get_repo(self.cfg.repo)
+        permissions = repo_data.get("permissions") or {}
+        if not permissions.get("push"):
+            raise PublishAuthError(
+                f"Token lacks write access to {self.cfg.repo}. Needs a fine-grained PAT "
+                f"with contents:write and pull_requests:write (or classic 'repo' scope)."
+            )
+
+        self.git.ensure_clone(self.clone_url)
+        self.git.fetch(self.cfg.base_branch)
+        self._preflight_done = True
+
+    # -- publish -------------------------------------------------------------
+
+    def publish(self, ctx: PublishContext) -> PublishResult:
+        self.preflight()
+
+        branch = self.branch_for(ctx.task_id)
+
+        # Idempotency: a restarted sandbox may regenerate a task we already published.
+        existing = None if self.cfg.dry_run else self.api.find_open_pr(self.cfg.repo, branch)
+        if existing:
+            self.logger.info(
+                "Task %s already has an open PR: %s", ctx.task_id, existing["html_url"]
+            )
+            return PublishResult(published=True, pr_url=existing["html_url"], branch=branch)
+
+        stale_branch = self.git.remote_branch_exists(branch)
+
+        self.git.fetch(self.cfg.base_branch)
+        self.git.checkout_fresh_branch(branch, f"origin/{self.cfg.base_branch}")
+
+        dest = self.clone_dir / self.cfg.tasks_path / ctx.task_id
+        if dest.exists():
+            shutil.rmtree(dest)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(ctx.task_dir, dest)
+
+        rel_path = f"{self.cfg.tasks_path}/{ctx.task_id}"
+        self.git.add(rel_path)
+        if not self.git.commit(render_commit_message(ctx)):
+            raise PublishError(
+                f"Nothing to commit for {ctx.task_id}; task directory {ctx.task_dir} may be empty."
+            )
+
+        # A stale branch is one this same task left behind on an earlier attempt, so
+        # overwriting it is safe. A fresh branch must never need force.
+        self.git.push(f"{branch}:refs/heads/{branch}", allow_force=stale_branch)
+
+        if self.cfg.dry_run:
+            self.logger.info(
+                "[dry-run] would open PR %r on %s (%s -> %s)",
+                render_pr_title(ctx),
+                self.cfg.repo,
+                branch,
+                self.cfg.base_branch,
+            )
+            return PublishResult(published=False, pr_url=None, branch=branch)
+
+        pr = self.api.create_pr(
+            repo=self.cfg.repo,
+            title=render_pr_title(ctx),
+            body=render_pr_body(ctx),
+            head=branch,
+            base=self.cfg.base_branch,
+        )
+        return PublishResult(published=True, pr_url=pr["html_url"], branch=branch)

--- a/src/swegen/publish/local_state.py
+++ b/src/swegen/publish/local_state.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from swegen.farm.state import StreamState
+
+
+class LocalStateStore:
+    """Farm state on local disk - the historical behavior.
+
+    Lost when an ephemeral sandbox dies; use GitStateStore when publishing.
+    """
+
+    def __init__(self, state_file: Path) -> None:
+        self.state_file = Path(state_file)
+
+    def load(self, repo: str) -> StreamState:
+        return StreamState.load(self.state_file, repo)
+
+    def save(self, state: StreamState) -> None:
+        state.save(self.state_file)

--- a/src/swegen/publish/null.py
+++ b/src/swegen/publish/null.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from .base import PublishContext, PublishResult
+
+
+class NullSink:
+    """Default sink: keeps tasks on local disk only.
+
+    Used whenever --publish-repo is absent, so `swegen create` and `swegen farm`
+    behave exactly as they did before publishing existed.
+    """
+
+    def preflight(self) -> None:
+        return None
+
+    def publish(self, ctx: PublishContext) -> PublishResult:
+        return PublishResult(published=False)

--- a/uv.lock
+++ b/uv.lock
@@ -319,18 +319,20 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.1.20"
+version = "0.2.116"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
+    { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/78/be7848b0a148269e07c3248967b4c382624967b15e9cc00351f5f7374583/claude_agent_sdk-0.1.20.tar.gz", hash = "sha256:bc3cb24f2dc8c7dc7362f52764051b20dbfcc16ec3e3d39787c4946d7ced3848", size = 56178, upload-time = "2026-01-16T21:20:11.864Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/b0f01a18bb119e595cc1e66d4adbe39bb09879a570e54793c222a142b662/claude_agent_sdk-0.2.116.tar.gz", hash = "sha256:37d6c9d98960c7ea41d1a7fd3331ad0b1bef68e559ed9cc5ccf9d00ae68adfcd", size = 268648, upload-time = "2026-07-11T01:04:47.192Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/e6/b34b8358a31cfc9c65df014d038036dbc86bd5f45ff6befc98e2cdb3407a/claude_agent_sdk-0.1.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3ff7ab0930fd34fd533fa6216af698df71e7c3a4fcbd2f29eb9d0cd7b51fdfa5", size = 54068867, upload-time = "2026-01-16T21:19:55.29Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/dc/08606e7a7377ca841ff6a961b0db930d13a98656b30176860c28d3407bcf/claude_agent_sdk-0.1.20-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:7756d35e6b5774270e880403513a347a9a4a504bfa28fd6a51cb0ed724a7851e", size = 68266982, upload-time = "2026-01-16T21:20:00.365Z" },
-    { url = "https://files.pythonhosted.org/packages/00/e3/d8de4f94a1c670ea4c4a933a272b291b85bd6471ac7a28875ef8ae768185/claude_agent_sdk-0.1.20-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:82dfb7d4f6494c9a977b5593773b91c507bcdd76437f289e2b8f8a91ae5f95c1", size = 69980411, upload-time = "2026-01-16T21:20:04.71Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/9f/af71db6b54e9de08e37c10e0a4d5ea7482227b15a63ee9f97b1599cd3ffc/claude_agent_sdk-0.1.20-py3-none-win_amd64.whl", hash = "sha256:7a5675b1c0bf489a5c82c79f6ad47c3915a50da66e1329dcb0d08332a04889d3", size = 72183062, upload-time = "2026-01-16T21:20:09.069Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cd/2ed6eaee9e5fa1a13d91d1ccbb9f09a3b53379acd55b3ccb9d6c94378a3f/claude_agent_sdk-0.2.116-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9ea5ababb44afdcc7e33b857ca3ad5008f906c30052aa2d957dacfa7f70ead9f", size = 71529658, upload-time = "2026-07-11T01:04:51.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/5a/28cefff3eacb8ba8a2caf2a8e7c944faca8c253157cc5aa207d87964c5cb/claude_agent_sdk-0.2.116-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:93c1f60ed1e4d73dc13f2c714bbe1be43798d9bb4067a6d563358c397b300801", size = 75044679, upload-time = "2026-07-11T01:04:56.414Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e8/6663bd715b1822db87a560aa04ddc51a1e36bbfb076441d96b3af827e572/claude_agent_sdk-0.2.116-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:e130166e5b1054b4e3741d957fd6759546fa657fa765385955a9ef12fdc545f9", size = 80070001, upload-time = "2026-07-11T01:05:01.862Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a2/305b81ee541ff1323920809803695c0294584f30b7e451a290213f53f4d7/claude_agent_sdk-0.2.116-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:d5e420912378cf66a90cf898bdd4567cc8f994308bd8011d7bd71968066f3894", size = 81082600, upload-time = "2026-07-11T01:05:06.688Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/cb/c492bf6d973837f00894604f2e0ad3b216a03163dc204bff14b3e7e596f0/claude_agent_sdk-0.2.116-py3-none-win_amd64.whl", hash = "sha256:fb8dbc73f52d103e08b30fe865199ea1d89e7b2197652a19a97a15b040cf685b", size = 80616940, upload-time = "2026-07-11T01:05:12.229Z" },
 ]
 
 [[package]]
@@ -2093,7 +2095,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=25.12.0" },
-    { name = "claude-agent-sdk", specifier = ">=0.1.20" },
+    { name = "claude-agent-sdk", specifier = ">=0.2.116" },
     { name = "click", specifier = ">=8.3.1" },
     { name = "docker", specifier = ">=7.1.0" },
     { name = "gitpython", specifier = ">=3.1.46" },


### PR DESCRIPTION
## Summary

Farming on ephemeral sandboxes (Daytona) loses tasks and resume state when the sandbox is reclaimed, since both live only under `.swegen/` on local disk. This adds an optional publish pipeline that makes the dataset repository the durable copy.

With `--publish-repo <owner/repo>` (on both `swegen create` and `swegen farm`):

- Each **validated** task is copied into a clone of the dataset repo, committed on a branch cut fresh from `main`, pushed, and opened as a PR (`task/<task_id>`) linking back to the source PR.
- **Farm state** is committed to a per-source-repo branch `farm-state/<owner>__<repo>` on the same repo after every PR, so a fresh sandbox resumes where the dead one stopped instead of re-burning Claude Code / OpenAI calls on PRs it already handled.
- Task branches and the state branch share one clone but live in **separate worktrees**, so the state push never disturbs the task branch being built. Per-source-repo branch names mean N containers farming N repos never contend.

Publishing is **off by default** — without `--publish-repo`, both commands behave exactly as before (`NullSink` + local state).

## Design

A new `src/swegen/publish/` package behind two protocols so the destination is swappable:
- `TaskSink` → `GitHubPRSink` (branch + PR per task) or `NullSink`.
- `StateStore` → `GitStateStore` (state branch, via a linked worktree) or `LocalStateStore`.
- `git_ops.py` (subprocess git; token injected per-invocation via `http.extraheader`, never written to `.git/config`), `gh_api.py` (REST with bounded retries honoring `Retry-After`), `body.py` (PR templates).

**Tokens:** `GIT_TOKEN` (falls back to `GITHUB_TOKEN`) needs `contents:write` + `pull_requests:write` on the dataset repo — deliberately separate from the read-only `GITHUB_TOKEN` used to fetch source PRs.

## Options

`--publish-repo`, `--publish-path` (default `tasks`), `--publish-base` (`main`), `--publish-branch-prefix` (`task/`), `--publish-state-branch-prefix` (`farm-state/`), `--publish-state-path` (`state`), `--publish-clone-dir`, `--publish-dry-run`, and `--cleanup-local` (delete each local task copy once it is durably published, to free disk on constrained sandboxes).

## Failure / recovery semantics (built for ephemeral sandboxes)

- **Any publish failure aborts the run** (validated tasks are kept on disk; a bad token fails at preflight). Continuing would spend a full Claude Code session per PR only to fail at the same wall.
- A **failed state push also aborts** — a stale durable cursor would make a resumed sandbox redo work. The state branch merges (never clobbers) a concurrent writer on a rejected push; the local mirror is kept in sync.
- **Claude rate/usage limits** (including the `rate_limit_event` SDK crash) raise `ClaudeRateLimitError`, abort the run, and leave the PR unprocessed for a re-run with a fresh token.
- **Publish-only retry:** a task that failed to publish is republished on the next run without regenerating (which would delete it).
- A **dedupe hit republishes** the on-disk task rather than skipping; `create.jsonl` carries a `published` flag so a task that never reached the repo is retried, not skipped.
- Publish I/O errors are `PublishError` (not bare `OSError`), so a disk hiccup keeps the validated task instead of deleting it. Dry runs never consume a source PR.

## Testing

Verified with `--publish-dry-run` against real GitHub repos: preflight refuses a read-only repo, branches are cut from `origin/main` and don't stack, the state branch is orphaned, and nothing is pushed. State merge/race, publish-retry, dry-run, rate-limit abort, and cleanup paths were exercised against local bare repos. **Not yet exercised against live GitHub:** a real `git push` / `POST /pulls` — the first real run is where dataset-repo branch protection would first surface.

Incidental fixes found while building this: `git add --force` for the template's `.gitignore`d `tasks/`; absolute publish clone dir (a relative `--state-dir` cloned into a doubled path); `mkdir(parents=True)` for nested `--output`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core farm/create persistence, GitHub writes, and run-abort behavior; misconfiguration or state-merge bugs could duplicate work or strand validated tasks, though failures are designed to stop the run and keep unpublished tasks on disk.
> 
> **Overview**
> Adds optional **`--publish-repo`** on `swegen create` and `swegen farm` so validated Harbor tasks land on per-task branches with GitHub PRs on a dataset repo, and farm progress is persisted on a per-source-repo **`farm-state/<slug>`** branch (via a linked git worktree). **`GIT_TOKEN`** (write on the dataset repo) is separate from read-only source PR fetching. Without `--publish-repo`, behavior is unchanged (`NullSink` / local state).
> 
> The new **`swegen/publish/`** layer implements `TaskSink` (`GitHubPRSink`) and `StateStore` (`GitStateStore` with merge-on-conflict, local mirror, `--reset` force-push semantics). **`create.jsonl`** gains a **`published`** flag; dedupe hits **republish** on-disk tasks instead of exiting. Farm **`StreamState`** tracks publish/Claude rate-limit pending PRs, **derives counters** from sets, and **aborts** on publish failure, failed state push, or **`ClaudeRateLimitError`** (with publish-only retries and fetcher exemptions). **`--cleanup-local`**, **`--publish-dry-run`**, and **`--build-cache_keep`** (targeted Harbor image prune vs `docker system prune -af`) support constrained sandboxes.
> 
> Also bumps **`claude-agent-sdk`** to **0.2.116** for `rate_limit_event` handling, shallow/blobless repo cache and Dockerfile clones, and **`base_sha`** fetch for diffs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d345278d2dbfbc53220e4fca35195f99e36e989. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

