### PR TITLE
perf(farm): cut dead time from the farm loop (delay, docker prune, git clones)

### DIFF
--- a/src/swegen/cli.py
+++ b/src/swegen/cli.py
@@ -371,6 +371,11 @@ def farm(
     docker_prune_batch: int = typer.Option(
         5, help="Run docker cleanup after every N PRs (0 to disable)", show_default=True
     ),
+    build_cache_keep: str = typer.Option(
+        "20GB",
+        help="Docker build cache to retain during cleanup (keeps base/runtime layers warm)",
+        show_default=True,
+    ),
     skip_list: str
     | None = typer.Option(None, help="Path to file with task IDs to skip (one per line)"),
     no_cache: bool = typer.Option(
@@ -425,6 +430,7 @@ def farm(
         cc_timeout=cc_timeout,
         api_delay=api_delay,
         task_delay=task_delay,
+        build_cache_keep=build_cache_keep,
         reset=reset,
         resume_from=resume_from,
         dry_run=dry_run,

--- a/src/swegen/config.py
+++ b/src/swegen/config.py
@@ -86,6 +86,10 @@ class FarmConfig:
         resume_from: Resume from date (ISO format or YYYY-MM-DD)
         dry_run: Only show what would run (no task generation)
         docker_prune_batch: Run docker cleanup after every N PRs (0 to disable)
+        build_cache_keep: Ceiling for the retained Docker build cache during cleanup
+            (any docker size string, e.g. "20GB"). Layers above this are evicted
+            least-recently-used first, so the base/runtime layers shared by every task
+            survive while per-task layers are reclaimed.
         skip_list: Path to file with task IDs to skip
         no_cache: Disable reusing cached Dockerfiles/test.sh
         require_minimum_difficulty: Require 3+ source files for task
@@ -111,6 +115,7 @@ class FarmConfig:
     resume_from: str | None = None
     dry_run: bool = False
     docker_prune_batch: int = 5
+    build_cache_keep: str = "20GB"
     skip_list: str | None = None
     no_cache: bool = False
     require_minimum_difficulty: bool = True

--- a/src/swegen/create/create.py
+++ b/src/swegen/create/create.py
@@ -464,6 +464,7 @@ def run_reversal(config: CreateConfig) -> None:
                 repo=pipeline.repo,
                 head_sha=metadata["head_sha"],
                 repo_url=metadata["repo_url"],
+                base_sha=metadata.get("base_sha"),
             )
             console.print(f"[dim]    Repo at: {repo_path}[/dim]")
 

--- a/src/swegen/create/orchestrator.py
+++ b/src/swegen/create/orchestrator.py
@@ -200,6 +200,7 @@ class PRToHarborPipeline:
                 repo=self.repo,
                 head_sha=metadata["head_sha"],
                 repo_url=metadata["repo_url"],
+                base_sha=metadata.get("base_sha"),
             )
         logger.info("Repo at: %s", repo_path)
 

--- a/src/swegen/create/repo_cache.py
+++ b/src/swegen/create/repo_cache.py
@@ -24,6 +24,7 @@ class RepoCache:
         repo: str,
         head_sha: str,
         repo_url: str | None = None,
+        base_sha: str | None = None,
     ) -> Path:
         """
         Get cached repo or clone it. Checkout the specified commit.
@@ -32,6 +33,8 @@ class RepoCache:
             repo: Repository in "owner/repo" format
             head_sha: Commit SHA to checkout
             repo_url: Optional clone URL (defaults to https://github.com/{repo}.git)
+            base_sha: Optional base commit SHA. When given, it is fetched alongside
+                head_sha so `git diff base..head` has both ends locally.
 
         Returns:
             Path to the repository root
@@ -42,9 +45,11 @@ class RepoCache:
         if repo_url is None:
             repo_url = f"https://github.com/{repo}.git"
 
+        wanted = [sha for sha in (base_sha, head_sha) if sha]
+
         if repo_path.exists() and (repo_path / ".git").exists():
             self.logger.debug("Using cached repo: %s", repo_path)
-            self._fetch_and_checkout(repo_path, head_sha)
+            self._fetch_and_checkout(repo_path, head_sha, wanted)
         else:
             self.logger.info("Cloning repo to cache: %s -> %s", repo, repo_path)
             self._clone(repo_url, repo_path, head_sha)
@@ -68,10 +73,13 @@ class RepoCache:
         """Clone a repository and checkout the specified commit."""
         repo_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Full clone for maximum CC context
-        self.logger.debug("Cloning %s...", repo_url)
+        # Partial clone: full commit graph and trees (so `git diff base..head` and any
+        # other history walk works), but no file contents up front. Blobs are fetched
+        # lazily, on demand -- which for the two commits we actually diff is a handful
+        # of files instead of every version of every file ever committed.
+        self.logger.debug("Cloning %s (blobless)...", repo_url)
         subprocess.run(
-            ["git", "clone", repo_url, str(repo_path)],
+            ["git", "clone", "--filter=blob:none", repo_url, str(repo_path)],
             check=True,
             capture_output=True,
         )
@@ -79,17 +87,39 @@ class RepoCache:
         # Checkout the target commit
         self._checkout(repo_path, head_sha)
 
-    def _fetch_and_checkout(self, repo_path: Path, head_sha: str) -> None:
-        """Fetch latest and checkout the specified commit."""
-        self.logger.debug("Fetching updates for %s...", repo_path)
+    def _fetch_and_checkout(
+        self,
+        repo_path: Path,
+        head_sha: str,
+        wanted_shas: list[str] | None = None,
+    ) -> None:
+        """Fetch the commits we need and checkout the specified one.
 
-        # Fetch all refs
-        subprocess.run(
-            ["git", "fetch", "--all"],
+        Fetches only the SHAs this task diffs, rather than `--all` (every branch and
+        every tag on every remote) which costs real time per PR on large repos. Falls
+        back to a full fetch if the targeted one fails -- e.g. a force-pushed SHA the
+        remote will no longer serve directly.
+        """
+        shas = wanted_shas or [head_sha]
+        self.logger.debug("Fetching %s for %s...", ", ".join(s[:8] for s in shas), repo_path)
+
+        fetched = subprocess.run(
+            ["git", "fetch", "origin", *shas],
             cwd=str(repo_path),
-            check=True,
+            check=False,
             capture_output=True,
         )
+        if fetched.returncode != 0:
+            self.logger.debug(
+                "Targeted fetch failed (%s); falling back to full fetch",
+                fetched.stderr.decode().strip() if fetched.stderr else "unknown",
+            )
+            subprocess.run(
+                ["git", "fetch", "--all"],
+                cwd=str(repo_path),
+                check=True,
+                capture_output=True,
+            )
 
         # Try to checkout the commit
         self._checkout(repo_path, head_sha)

--- a/src/swegen/create/task_skeleton.py
+++ b/src/swegen/create/task_skeleton.py
@@ -40,7 +40,9 @@ def generate_dockerfile(params: SkeletonParams) -> str:
     - Post-patch rebuild (if needed)
     
     Git clone strategy:
-    - Simple + robust: clone, then fetch the exact commit SHA.
+    - Shallow: init an empty repo, then fetch only the exact commit SHA at depth 1.
+      The image needs a single commit's worktree (the .git dir is deleted at the end),
+      so fetching history would be downloaded and then thrown away.
     - NOTE: `head_sha` currently comes from the PR's HEAD branch tip (GitHub API).
     - If the PR was squash-merged/rebased, that commit may not be on any normal branch.
     - In that case, fetching `refs/pull/<n>/head` is a robust fallback without fetching ALL PR refs.
@@ -78,9 +80,11 @@ RUN apt-get update && apt-get install -y \\
 
 WORKDIR /app
 
-# Clone repo at HEAD commit (with fix applied)
-RUN git clone {params.repo_url} src && \\
+# Fetch repo at HEAD commit (with fix applied).
+# Shallow on purpose: only this one commit's worktree is needed, and .git is removed below.
+RUN git init src && \\
     cd src && \\
+    git remote add origin {params.repo_url} && \\
     (git fetch --depth 1 origin {params.head_sha} || git fetch --depth 1 origin "+refs/pull/{params.pr_number}/head:refs/remotes/origin/pr/{params.pr_number}") && \\
     git checkout --detach FETCH_HEAD && \\
     git submodule update --init --recursive

--- a/src/swegen/farm/stream_farm.py
+++ b/src/swegen/farm/stream_farm.py
@@ -29,6 +29,19 @@ from .state import StreamState
 
 DOCKER_CLEANUP_CMD = "docker system prune -af"
 
+# Failure categories where the PR was rejected by a cheap filter, before the
+# Claude Code session ran. These paths make only a couple of GitHub API calls and
+# never touch the Anthropic API, so there is nothing to rate limit against and the
+# inter-task delay is pure dead time.
+SKIPPED_CATEGORIES = frozenset(
+    {
+        "trivial",
+        "no_issue",
+        "no_tests",
+        "already_exists",
+    }
+)
+
 
 class StreamFarmer:
     """Manages continuous PR farming with streaming.
@@ -237,9 +250,16 @@ class StreamFarmer:
         # Show result
         self._print_result(result)
 
-        # Rate limit protection: sleep between PRs
-        self.console.print(f"[dim]Waiting {self.config.task_delay} seconds before next PR...[/dim]")
-        time.sleep(self.config.task_delay)
+        # Rate limit protection: only sleep after PRs that actually ran a CC session
+        if not self._should_delay_after(result):
+            self.console.print(
+                f"[dim]Skipping delay ({result.category or result.status}, no CC session run)[/dim]"
+            )
+        elif self.config.task_delay > 0:
+            self.console.print(
+                f"[dim]Waiting {self.config.task_delay} seconds before next PR...[/dim]"
+            )
+            time.sleep(self.config.task_delay)
 
         # Periodic summary
         if self.state.total_processed % 10 == 0:
@@ -249,6 +269,17 @@ class StreamFarmer:
         if self.config.docker_prune_batch > 0:
             if self.state.total_processed % self.config.docker_prune_batch == 0:
                 self._prune_docker()
+
+    def _should_delay_after(self, result: TaskResult) -> bool:
+        """Whether to sleep before the next PR.
+
+        Only PRs that reached the Claude Code session need the delay. Dry runs and
+        PRs rejected by a cheap filter (trivial, no linked issue, no tests, already
+        exists) did no meaningful API work, so waiting on them is dead time.
+        """
+        if result.status == "dry-run":
+            return False
+        return result.category not in SKIPPED_CATEGORIES
 
     def _print_result(self, result: TaskResult) -> None:
         """Print the result of processing a PR.

--- a/src/swegen/farm/stream_farm.py
+++ b/src/swegen/farm/stream_farm.py
@@ -27,7 +27,29 @@ from .farm_hand import (
 from .fetcher import StreamingPRFetcher, load_skip_list
 from .state import StreamState
 
-DOCKER_CLEANUP_CMD = "docker system prune -af"
+# Harbor names every task image "hb__{environment_name}" (see harbor's docker
+# environment). Matching that prefix lets us reclaim the per-task images -- which are
+# the ones that actually consume disk -- without touching base images (ubuntu, language
+# runtimes) or any unrelated image on the host, both of which `docker system prune -af`
+# would happily delete.
+HARBOR_IMAGE_GLOB = "hb__*"
+
+
+def docker_cleanup_cmds(build_cache_keep: str) -> list[str]:
+    """Docker cleanup steps, in order.
+
+    Containers are pruned before images so image removal is not blocked by stopped
+    trial containers. The build cache is trimmed to a ceiling rather than emptied:
+    layers are evicted least-recently-used first, so the base + runtime layers shared
+    by every task survive and rebuilds stay warm, while the per-task layers (whose
+    cache keys embed the task's head SHA, so they are never hit again) are reclaimed.
+    """
+    return [
+        "docker container prune -f",
+        f'docker image ls --filter "reference={HARBOR_IMAGE_GLOB}" -q | xargs -r docker rmi -f',
+        "docker volume prune -f",
+        f"docker builder prune -f --keep-storage {build_cache_keep}",
+    ]
 
 # Failure categories where the PR was rejected by a cheap filter, before the
 # Claude Code session ran. These paths make only a couple of GitHub API calls and
@@ -333,43 +355,48 @@ class StreamFarmer:
             )
             return
 
+        cmds = docker_cleanup_cmds(self.config.build_cache_keep)
         self.console.print(
             Panel(
-                f"Running docker cleanup: {DOCKER_CLEANUP_CMD}",
+                "Running docker cleanup:\n" + "\n".join(f"  {cmd}" for cmd in cmds),
                 title="Disk cleanup",
                 border_style="yellow",
             )
         )
 
-        try:
-            result = subprocess.run(
-                DOCKER_CLEANUP_CMD,
-                shell=True,
-                capture_output=True,
-                text=True,
-                timeout=600,
-            )
-            if result.returncode == 0:
-                stdout = result.stdout.strip()
-                if stdout:
-                    # Show summary if available
-                    lines = stdout.split("\n")
-                    summary_lines = [
-                        line
-                        for line in lines
-                        if "reclaimed" in line.lower()
-                        or "deleted" in line.lower()
-                        or "total" in line.lower()
-                    ]
-                    if summary_lines:
-                        self.console.print(f"[dim]{summary_lines[0]}[/dim]")
-                self.console.print("[green]Docker cleanup completed[/green]")
-            else:
-                self.console.print(f"[red]Docker cleanup failed (exit {result.returncode})[/red]")
+        for cmd in cmds:
+            try:
+                result = subprocess.run(
+                    cmd,
+                    shell=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=600,
+                )
+            except subprocess.TimeoutExpired:
+                self.console.print(f"[red]Docker cleanup timed out after 600s: {cmd}[/red]")
+                continue
+
+            if result.returncode != 0:
+                # Keep going: a failed step (e.g. an image still in use) should not
+                # prevent the remaining steps from reclaiming what they can.
+                self.console.print(
+                    f"[red]Docker cleanup step failed (exit {result.returncode}): {cmd}[/red]"
+                )
                 if result.stderr:
                     self.console.print(f"[red]{result.stderr.strip()}[/red]")
-        except subprocess.TimeoutExpired:
-            self.console.print("[red]Docker prune timed out after 600s[/red]")
+                continue
+
+            # Show the reclaimed-space summary when docker reports one.
+            summary_lines = [
+                line
+                for line in result.stdout.strip().split("\n")
+                if "reclaimed" in line.lower() or "total" in line.lower()
+            ]
+            if summary_lines:
+                self.console.print(f"[dim]{summary_lines[0]}[/dim]")
+
+        self.console.print("[green]Docker cleanup completed[/green]")
 
     def _save_state(self) -> None:
         """Save state to file."""


### PR DESCRIPTION
Three independent throughput fixes for the farm loop. No change to what a task
*is* -- generated task contents are unchanged; this only removes work the
pipeline was doing and throwing away.

## 1. Skip the inter-PR delay for cheaply rejected PRs

`task_delay` (default 60s) exists to protect against GitHub rate limits after a
full task generation. It was slept unconditionally -- including for PRs rejected
by a cheap filter (trivial, no linked issue, no tests, already exists) and for
dry runs. Those paths make a couple of GitHub API calls, never reach the Claude
Code session, and have nothing to rate limit against.

Now only PRs that actually ran a CC session pay the delay. Validation failures
and rate-limit/other errors still delay, since those did real work.

## 2. Stop nuking base images and the build cache on prune

The periodic cleanup ran `docker system prune -af`, which deletes every image not
held by a running container *plus* the entire BuildKit cache. Two costs:

- The next task rebuilds from cold: re-pull the base image, re-run `apt-get`, and
  re-install the language runtime.
- Every unrelated image on the host is collateral damage. 

Replaced with a targeted sweep: remove Harbor's per-task images (`hb__*`, which is
where the disk actually goes), and trim the build cache to a ceiling instead of
emptying it. BuildKit evicts least-recently-used first, so the base + runtime
layers shared by every task survive while per-task layers -- whose cache keys embed
the head SHA and are never hit again -- are reclaimed.

The ceiling is configurable via `--build-cache-keep` (default 20GB).

Note this prune is deliberately *narrower* than the old one, so steady-state disk
use is higher; `--build-cache-keep` is the knob if a box gets tight.

## 3. Stop downloading git history nobody reads

**Task image.** The Dockerfile ran a full `git clone` and then immediately fetched
the one commit it wanted at `--depth 1`, before deleting `.git` at the end of the
build. Every byte of that history was downloaded and thrown away -- on every image
build, and there are several per task since CC re-runs harbor while iterating.
Replaced the clone with `git init` + `remote add` + the existing depth-1 fetch:
same commit, same `refs/pull/N/head` fallback, no history. `.git` is still removed
at the end, and `git submodule update` is unchanged.

**RepoCache.** This one *does* need real history, since `generate_diffs` runs
`git diff base..head`. But it does not need file *contents* for all of history, so
it now clones with `--filter=blob:none`: the full commit graph and trees, with blobs
fetched lazily only for the files actually diffed. Also replaced the per-PR
`git fetch --all` (every branch and tag on every remote) with a targeted fetch of
just the base and head SHAs, falling back to a full fetch if the remote will not
serve them directly (e.g. after a force-push), so this cannot make a
previously-working PR fail.

### Verification

The Dockerfile change was checked for behavioral parity against a real merged PR
(`pallets/click#3681`):

- **Worktree byte-identical**: 163 files, same SHA-256 for every one. This is what
  the image ships, since `.git` is deleted.
- **History depth identical**: both end up shallow with exactly 1 commit. The old
  `git fetch --depth 1` was *already* converting the full clone into a shallow repo,
  so the history was being discarded by git itself before `rm -rf .git` ran.
- **`git describe` fails in both** (old: "No tags can describe", new: "No names
  found"), so version-from-git tooling (setuptools_scm etc.) was already degraded
  before this change. No regression.

The blobless clone produces a **byte-identical diff** to a full clone (11,172 bytes
both), and the changed-file list matches GitHub's compare API.

Measured on `python/cpython`, a repo we farm:

| | full clone (before) | blobless (after) |
|---|---|---|
| time | 7m 04s | 1m 30s |
| .git size | 862 MB | 259 MB |

Existing repos already in the `.swegen/repos` cache stay full clones; only newly
cloned repos get the blobless treatment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Throughput and infrastructure tuning only; git fetch fallbacks and parity checks reduce regression risk, though steady-state disk use rises versus the old aggressive prune.
> 
> **Overview**
> Improves **farm throughput** without changing generated task content: less idle waiting, smarter Docker cleanup, and lighter git I/O.
> 
> **Farm loop:** `task_delay` now runs only after PRs that actually reached a Claude Code session. Dry runs and cheap-filter skips (`trivial`, `no_issue`, `no_tests`, `already_exists`) no longer sleep 60s by default.
> 
> **Docker:** Periodic cleanup drops `docker system prune -af` in favor of a staged sweep—container prune, remove Harbor task images (`hb__*`), volume prune, then `docker builder prune` with **`--keep-storage`** (new farm flag **`--build-cache-keep`**, default `20GB`) so shared base/runtime cache layers stay warm.
> 
> **Git:** Task **Dockerfile** skeleton uses `git init` + depth-1 fetch (same PR-head fallback) instead of a full clone before discarding `.git`. **`RepoCache`** clones with `--filter=blob:none`, fetches only `base_sha` and `head_sha` on updates (fallback to `git fetch --all`), and callers pass `base_sha` so `git diff base..head` works locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ae9a50af8ed7335532ea97450c03b0822f8d311. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->