### PR TITLE
Merge perf fixes (#59) into the publish branch

### DIFF
--- a/src/swegen/cli.py
+++ b/src/swegen/cli.py
@@ -371,6 +371,11 @@ def farm(
     docker_prune_batch: int = typer.Option(
         5, help="Run docker cleanup after every N PRs (0 to disable)", show_default=True
     ),
+    build_cache_keep: str = typer.Option(
+        "20GB",
+        help="Docker build cache to retain during cleanup (keeps base/runtime layers warm)",
+        show_default=True,
+    ),
     skip_list: str
     | None = typer.Option(None, help="Path to file with task IDs to skip (one per line)"),
     no_cache: bool = typer.Option(
@@ -425,6 +430,7 @@ def farm(
         cc_timeout=cc_timeout,
         api_delay=api_delay,
         task_delay=task_delay,
+        build_cache_keep=build_cache_keep,
         reset=reset,
         resume_from=resume_from,
         dry_run=dry_run,

--- a/src/swegen/config.py
+++ b/src/swegen/config.py
@@ -86,6 +86,10 @@ class FarmConfig:
         resume_from: Resume from date (ISO format or YYYY-MM-DD)
         dry_run: Only show what would run (no task generation)
         docker_prune_batch: Run docker cleanup after every N PRs (0 to disable)
+        build_cache_keep: Ceiling for the retained Docker build cache during cleanup
+            (any docker size string, e.g. "20GB"). Layers above this are evicted
+            least-recently-used first, so the base/runtime layers shared by every task
+            survive while per-task layers are reclaimed.
         skip_list: Path to file with task IDs to skip
         no_cache: Disable reusing cached Dockerfiles/test.sh
         require_minimum_difficulty: Require 3+ source files for task
@@ -111,6 +115,7 @@ class FarmConfig:
     resume_from: str | None = None
     dry_run: bool = False
     docker_prune_batch: int = 5
+    build_cache_keep: str = "20GB"
     skip_list: str | None = None
     no_cache: bool = False
     require_minimum_difficulty: bool = True

--- a/src/swegen/create/create.py
+++ b/src/swegen/create/create.py
@@ -464,6 +464,7 @@ def run_reversal(config: CreateConfig) -> None:
                 repo=pipeline.repo,
                 head_sha=metadata["head_sha"],
                 repo_url=metadata["repo_url"],
+                base_sha=metadata.get("base_sha"),
             )
             console.print(f"[dim]    Repo at: {repo_path}[/dim]")
 

--- a/src/swegen/create/orchestrator.py
+++ b/src/swegen/create/orchestrator.py
@@ -200,6 +200,7 @@ class PRToHarborPipeline:
                 repo=self.repo,
                 head_sha=metadata["head_sha"],
                 repo_url=metadata["repo_url"],
+                base_sha=metadata.get("base_sha"),
             )
         logger.info("Repo at: %s", repo_path)
 

--- a/src/swegen/create/repo_cache.py
+++ b/src/swegen/create/repo_cache.py
@@ -24,6 +24,7 @@ class RepoCache:
         repo: str,
         head_sha: str,
         repo_url: str | None = None,
+        base_sha: str | None = None,
     ) -> Path:
         """
         Get cached repo or clone it. Checkout the specified commit.
@@ -32,6 +33,8 @@ class RepoCache:
             repo: Repository in "owner/repo" format
             head_sha: Commit SHA to checkout
             repo_url: Optional clone URL (defaults to https://github.com/{repo}.git)
+            base_sha: Optional base commit SHA. When given, it is fetched alongside
+                head_sha so `git diff base..head` has both ends locally.
 
         Returns:
             Path to the repository root
@@ -42,9 +45,11 @@ class RepoCache:
         if repo_url is None:
             repo_url = f"https://github.com/{repo}.git"
 
+        wanted = [sha for sha in (base_sha, head_sha) if sha]
+
         if repo_path.exists() and (repo_path / ".git").exists():
             self.logger.debug("Using cached repo: %s", repo_path)
-            self._fetch_and_checkout(repo_path, head_sha)
+            self._fetch_and_checkout(repo_path, head_sha, wanted)
         else:
             self.logger.info("Cloning repo to cache: %s -> %s", repo, repo_path)
             self._clone(repo_url, repo_path, head_sha)
@@ -68,10 +73,13 @@ class RepoCache:
         """Clone a repository and checkout the specified commit."""
         repo_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Full clone for maximum CC context
-        self.logger.debug("Cloning %s...", repo_url)
+        # Partial clone: full commit graph and trees (so `git diff base..head` and any
+        # other history walk works), but no file contents up front. Blobs are fetched
+        # lazily, on demand -- which for the two commits we actually diff is a handful
+        # of files instead of every version of every file ever committed.
+        self.logger.debug("Cloning %s (blobless)...", repo_url)
         subprocess.run(
-            ["git", "clone", repo_url, str(repo_path)],
+            ["git", "clone", "--filter=blob:none", repo_url, str(repo_path)],
             check=True,
             capture_output=True,
         )
@@ -79,17 +87,39 @@ class RepoCache:
         # Checkout the target commit
         self._checkout(repo_path, head_sha)
 
-    def _fetch_and_checkout(self, repo_path: Path, head_sha: str) -> None:
-        """Fetch latest and checkout the specified commit."""
-        self.logger.debug("Fetching updates for %s...", repo_path)
+    def _fetch_and_checkout(
+        self,
+        repo_path: Path,
+        head_sha: str,
+        wanted_shas: list[str] | None = None,
+    ) -> None:
+        """Fetch the commits we need and checkout the specified one.
 
-        # Fetch all refs
-        subprocess.run(
-            ["git", "fetch", "--all"],
+        Fetches only the SHAs this task diffs, rather than `--all` (every branch and
+        every tag on every remote) which costs real time per PR on large repos. Falls
+        back to a full fetch if the targeted one fails -- e.g. a force-pushed SHA the
+        remote will no longer serve directly.
+        """
+        shas = wanted_shas or [head_sha]
+        self.logger.debug("Fetching %s for %s...", ", ".join(s[:8] for s in shas), repo_path)
+
+        fetched = subprocess.run(
+            ["git", "fetch", "origin", *shas],
             cwd=str(repo_path),
-            check=True,
+            check=False,
             capture_output=True,
         )
+        if fetched.returncode != 0:
+            self.logger.debug(
+                "Targeted fetch failed (%s); falling back to full fetch",
+                fetched.stderr.decode().strip() if fetched.stderr else "unknown",
+            )
+            subprocess.run(
+                ["git", "fetch", "--all"],
+                cwd=str(repo_path),
+                check=True,
+                capture_output=True,
+            )
 
         # Try to checkout the commit
         self._checkout(repo_path, head_sha)

--- a/src/swegen/create/task_skeleton.py
+++ b/src/swegen/create/task_skeleton.py
@@ -40,7 +40,9 @@ def generate_dockerfile(params: SkeletonParams) -> str:
     - Post-patch rebuild (if needed)
     
     Git clone strategy:
-    - Simple + robust: clone, then fetch the exact commit SHA.
+    - Shallow: init an empty repo, then fetch only the exact commit SHA at depth 1.
+      The image needs a single commit's worktree (the .git dir is deleted at the end),
+      so fetching history would be downloaded and then thrown away.
     - NOTE: `head_sha` currently comes from the PR's HEAD branch tip (GitHub API).
     - If the PR was squash-merged/rebased, that commit may not be on any normal branch.
     - In that case, fetching `refs/pull/<n>/head` is a robust fallback without fetching ALL PR refs.
@@ -78,9 +80,11 @@ RUN apt-get update && apt-get install -y \\
 
 WORKDIR /app
 
-# Clone repo at HEAD commit (with fix applied)
-RUN git clone {params.repo_url} src && \\
+# Fetch repo at HEAD commit (with fix applied).
+# Shallow on purpose: only this one commit's worktree is needed, and .git is removed below.
+RUN git init src && \\
     cd src && \\
+    git remote add origin {params.repo_url} && \\
     (git fetch --depth 1 origin {params.head_sha} || git fetch --depth 1 origin "+refs/pull/{params.pr_number}/head:refs/remotes/origin/pr/{params.pr_number}") && \\
     git checkout --detach FETCH_HEAD && \\
     git submodule update --init --recursive

--- a/src/swegen/farm/stream_farm.py
+++ b/src/swegen/farm/stream_farm.py
@@ -29,6 +29,19 @@ from .state import StreamState
 
 DOCKER_CLEANUP_CMD = "docker system prune -af"
 
+# Failure categories where the PR was rejected by a cheap filter, before the
+# Claude Code session ran. These paths make only a couple of GitHub API calls and
+# never touch the Anthropic API, so there is nothing to rate limit against and the
+# inter-task delay is pure dead time.
+SKIPPED_CATEGORIES = frozenset(
+    {
+        "trivial",
+        "no_issue",
+        "no_tests",
+        "already_exists",
+    }
+)
+
 
 class StreamFarmer:
     """Manages continuous PR farming with streaming.
@@ -237,9 +250,16 @@ class StreamFarmer:
         # Show result
         self._print_result(result)
 
-        # Rate limit protection: sleep between PRs
-        self.console.print(f"[dim]Waiting {self.config.task_delay} seconds before next PR...[/dim]")
-        time.sleep(self.config.task_delay)
+        # Rate limit protection: only sleep after PRs that actually ran a CC session
+        if not self._should_delay_after(result):
+            self.console.print(
+                f"[dim]Skipping delay ({result.category or result.status}, no CC session run)[/dim]"
+            )
+        elif self.config.task_delay > 0:
+            self.console.print(
+                f"[dim]Waiting {self.config.task_delay} seconds before next PR...[/dim]"
+            )
+            time.sleep(self.config.task_delay)
 
         # Periodic summary
         if self.state.total_processed % 10 == 0:
@@ -249,6 +269,17 @@ class StreamFarmer:
         if self.config.docker_prune_batch > 0:
             if self.state.total_processed % self.config.docker_prune_batch == 0:
                 self._prune_docker()
+
+    def _should_delay_after(self, result: TaskResult) -> bool:
+        """Whether to sleep before the next PR.
+
+        Only PRs that reached the Claude Code session need the delay. Dry runs and
+        PRs rejected by a cheap filter (trivial, no linked issue, no tests, already
+        exists) did no meaningful API work, so waiting on them is dead time.
+        """
+        if result.status == "dry-run":
+            return False
+        return result.category not in SKIPPED_CATEGORIES
 
     def _print_result(self, result: TaskResult) -> None:
         """Print the result of processing a PR.

--- a/src/swegen/farm/stream_farm.py
+++ b/src/swegen/farm/stream_farm.py
@@ -27,7 +27,29 @@ from .farm_hand import (
 from .fetcher import StreamingPRFetcher, load_skip_list
 from .state import StreamState
 
-DOCKER_CLEANUP_CMD = "docker system prune -af"
+# Harbor names every task image "hb__{environment_name}" (see harbor's docker
+# environment). Matching that prefix lets us reclaim the per-task images -- which are
+# the ones that actually consume disk -- without touching base images (ubuntu, language
+# runtimes) or any unrelated image on the host, both of which `docker system prune -af`
+# would happily delete.
+HARBOR_IMAGE_GLOB = "hb__*"
+
+
+def docker_cleanup_cmds(build_cache_keep: str) -> list[str]:
+    """Docker cleanup steps, in order.
+
+    Containers are pruned before images so image removal is not blocked by stopped
+    trial containers. The build cache is trimmed to a ceiling rather than emptied:
+    layers are evicted least-recently-used first, so the base + runtime layers shared
+    by every task survive and rebuilds stay warm, while the per-task layers (whose
+    cache keys embed the task's head SHA, so they are never hit again) are reclaimed.
+    """
+    return [
+        "docker container prune -f",
+        f'docker image ls --filter "reference={HARBOR_IMAGE_GLOB}" -q | xargs -r docker rmi -f',
+        "docker volume prune -f",
+        f"docker builder prune -f --keep-storage {build_cache_keep}",
+    ]
 
 # Failure categories where the PR was rejected by a cheap filter, before the
 # Claude Code session ran. These paths make only a couple of GitHub API calls and
@@ -333,43 +355,48 @@ class StreamFarmer:
             )
             return
 
+        cmds = docker_cleanup_cmds(self.config.build_cache_keep)
         self.console.print(
             Panel(
-                f"Running docker cleanup: {DOCKER_CLEANUP_CMD}",
+                "Running docker cleanup:\n" + "\n".join(f"  {cmd}" for cmd in cmds),
                 title="Disk cleanup",
                 border_style="yellow",
             )
         )
 
-        try:
-            result = subprocess.run(
-                DOCKER_CLEANUP_CMD,
-                shell=True,
-                capture_output=True,
-                text=True,
-                timeout=600,
-            )
-            if result.returncode == 0:
-                stdout = result.stdout.strip()
-                if stdout:
-                    # Show summary if available
-                    lines = stdout.split("\n")
-                    summary_lines = [
-                        line
-                        for line in lines
-                        if "reclaimed" in line.lower()
-                        or "deleted" in line.lower()
-                        or "total" in line.lower()
-                    ]
-                    if summary_lines:
-                        self.console.print(f"[dim]{summary_lines[0]}[/dim]")
-                self.console.print("[green]Docker cleanup completed[/green]")
-            else:
-                self.console.print(f"[red]Docker cleanup failed (exit {result.returncode})[/red]")
+        for cmd in cmds:
+            try:
+                result = subprocess.run(
+                    cmd,
+                    shell=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=600,
+                )
+            except subprocess.TimeoutExpired:
+                self.console.print(f"[red]Docker cleanup timed out after 600s: {cmd}[/red]")
+                continue
+
+            if result.returncode != 0:
+                # Keep going: a failed step (e.g. an image still in use) should not
+                # prevent the remaining steps from reclaiming what they can.
+                self.console.print(
+                    f"[red]Docker cleanup step failed (exit {result.returncode}): {cmd}[/red]"
+                )
                 if result.stderr:
                     self.console.print(f"[red]{result.stderr.strip()}[/red]")
-        except subprocess.TimeoutExpired:
-            self.console.print("[red]Docker prune timed out after 600s[/red]")
+                continue
+
+            # Show the reclaimed-space summary when docker reports one.
+            summary_lines = [
+                line
+                for line in result.stdout.strip().split("\n")
+                if "reclaimed" in line.lower() or "total" in line.lower()
+            ]
+            if summary_lines:
+                self.console.print(f"[dim]{summary_lines[0]}[/dim]")
+
+        self.console.print("[green]Docker cleanup completed[/green]")
 
     def _save_state(self) -> None:
         """Save state to file."""


### PR DESCRIPTION
Brings the three farm-throughput fixes from #59 onto `feat/publish-tasks-as-prs`
(#56), so the publish branch can be farmed with them while both PRs wait on
review against `main`.

Replaces #60, which cannot be used as-is: its head is #59's branch, so resolving
its conflicts (by merging the base into the head) would have pulled the entire
publish feature into #59's diff against `main`. This branch keeps #59 clean.

### Conflicts resolved

Both were in `stream_farm.py`, and both sides were kept:

- **`_process_pr`**: #56's publish-health early-return runs *before* #59's
  inter-PR delay, so a publish or state-push failure still aborts the run without
  first sleeping for `task_delay`.
- **Helper methods**: `_should_delay_after` (#59) and
  `_check_publish_health` / `_abort` / `_publish_is_dry_run` (#56) are independent
  additions in the same region; all four kept.

### Semantic interactions checked

- #56 adds two failure categories, `rate_limited` and `publish_failed`. Both are
  deliberately **absent** from `SKIPPED_CATEGORIES`: each means a Claude Code
  session actually ran, so each would warrant the rate-limit delay. In practice
  they abort the run in `_check_publish_health` before the delay is reached.
- The prune and progress cadence now keys off #56's `prs_seen` counter (PRs seen
  this run) rather than `state.total_processed`. #59 did not touch that.
- The CLI flags from both PRs coexist (`--build-cache-keep` alongside
  `--publish-repo` and friends), and the delay decision was exercised across every
  category either PR can produce.

Merge #59 and #56 into `main` in either order once approved; this branch is only
to unblock farming in the meantime.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operational tuning (git fetch strategy, Docker prune scope, optional delay skip); no auth or data-model changes, with fallbacks when targeted git fetch fails.
> 
> **Overview**
> Improves **continuous farm** throughput and disk use without changing publish behavior.
> 
> **Farm loop:** `task_delay` is skipped when a PR never ran Claude Code (dry-run, trivial, no issue, no tests, already exists). Publish/state abort paths still run before any sleep.
> 
> **Docker cleanup:** Replaces global `docker system prune -af` with ordered steps—container prune, remove only Harbor task images (`hb__*`), volume prune, then `docker builder prune` with a configurable **`--build-cache-keep`** ceiling (default `20GB`) so shared base/runtime layers stay warm.
> 
> **Git for task generation:** Local **repo cache** uses blobless clones and fetches only `base_sha`/`head_sha` (fallback to full fetch). Callers pass **`base_sha`** so `git diff base..head` works. Task **Dockerfile skeleton** uses shallow `git init` + depth-1 fetch instead of a full clone inside the image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17a83196575ab2119666834d9ca04750674b36c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->