### PR TITLE
fix(farm): stop discarding the failure category the handler set

### DIFF
--- a/src/swegen/farm/farm_hand.py
+++ b/src/swegen/farm/farm_hand.py
@@ -399,12 +399,11 @@ def _run_reversal_for_pr_impl(
         error_category = "already_exists"
         success = False
     except Exception as e:
-        # Other errors
+        # Unexpected error: nothing set a category for us, so sniff the message.
         error_msg = f"{type(e).__name__}: {str(e)}"
         if config.verbose:
             console.print(f"[red]{traceback.format_exc()}[/red]")
-        # Classify the error
-        error_category, _ = _classify_failure(error_msg)
+        error_category, error_msg = _classify_failure(error_msg)
         success = False
 
     if success:
@@ -474,8 +473,12 @@ def _run_reversal_for_pr_impl(
             category=failure_category,
         )
 
-    # Pipeline failed
-    failure_category, failure_reason = _classify_failure(error_msg)
+    # Pipeline failed. Trust the category the handler above already established -- do not
+    # re-derive it by grepping the message. _classify_failure only recognises a trivial PR
+    # by the literal word "trivial", so a TrivialPRError raised for the file-count bounds
+    # ("Too many source files modified (14, max 10)") was landing in "other": it delayed
+    # 60s before the next PR and was counted under Other Errors in the summary.
+    failure_category, failure_reason = error_category, error_msg
 
     if failure_category == "publish_failed":
         # The task itself is valid - it passed every gate and only the push/PR failed.

--- a/src/swegen/farm/farm_hand.py
+++ b/src/swegen/farm/farm_hand.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import shutil
 import time
 import traceback
@@ -160,6 +161,46 @@ def _classify_failure(stderr: str) -> tuple[str, str]:
 
     message = (stderr or "Unknown error").replace("\n", " ")
     return "other", message
+
+
+# Friendly label per category, with the phrase that means the exception's own message
+# already says it. Typed exceptions carry the diagnostic detail ("Too many source files
+# modified (14, max 10)") that a bare label would throw away, so the label is only
+# prepended when the message does not already convey it -- otherwise it just stutters
+# ("Task already exists (skipped): Task already exists: ..."). Categories that arrive only
+# via _classify_failure are absent on purpose: their message *is* the friendly string.
+# Exceptions prefix themselves with the PR they concern ("PR #9413: ..." or
+# "PR #9413 is too trivial: ..."), and the callers print the reason as "PR #N: {message}".
+# Stripping the self-prefix is what removes the doubled "PR #9413: PR #9413:".
+_SELF_PREFIX_RE = re.compile(r"^PR #\d+\b(?:\s+is)?\s*:?\s*", re.IGNORECASE)
+
+CATEGORY_LABELS = {
+    "trivial": ("Trivial PR (skipped)", "trivial"),
+    "no_issue": ("No linked issue (skipped)", "linked issue"),
+    "validation_failed": ("Validation failed (NOP or Oracle)", "validation"),
+    "already_exists": ("Task already exists (skipped)", "already exists"),
+}
+
+
+def _failure_message(pr_number: int, category: str | None, error_msg: str) -> str:
+    """Render the human-facing reason for a failed PR.
+
+    Strips any leading "PR #N: " the exception prefixed itself with: the callers print
+    this as "PR #N: {message}", which is where the doubled "PR #9413: PR #9413:" in the
+    farm log came from.
+    """
+    detail = _SELF_PREFIX_RE.sub("", (error_msg or "").replace("\n", " ").strip())
+    if detail:
+        detail = detail[0].upper() + detail[1:]
+
+    label, spoken_for = CATEGORY_LABELS.get(category or "", (None, None))
+    if not label:
+        return detail or "Unknown error"
+    if not detail:
+        return label
+    if spoken_for in detail.lower():
+        return detail
+    return f"{label}: {detail}"
 
 
 def _print_success(
@@ -478,7 +519,8 @@ def _run_reversal_for_pr_impl(
     # by the literal word "trivial", so a TrivialPRError raised for the file-count bounds
     # ("Too many source files modified (14, max 10)") was landing in "other": it delayed
     # 60s before the next PR and was counted under Other Errors in the summary.
-    failure_category, failure_reason = error_category, error_msg
+    failure_category = error_category
+    failure_reason = _failure_message(pr.number, error_category, error_msg)
 
     if failure_category == "publish_failed":
         # The task itself is valid - it passed every gate and only the push/PR failed.

--- a/src/swegen/farm/farm_hand.py
+++ b/src/swegen/farm/farm_hand.py
@@ -163,17 +163,14 @@ def _classify_failure(stderr: str) -> tuple[str, str]:
     return "other", message
 
 
-# Friendly label per category, with the phrase that means the exception's own message
-# already says it. Typed exceptions carry the diagnostic detail ("Too many source files
-# modified (14, max 10)") that a bare label would throw away, so the label is only
-# prepended when the message does not already convey it -- otherwise it just stutters
-# ("Task already exists (skipped): Task already exists: ..."). Categories that arrive only
-# via _classify_failure are absent on purpose: their message *is* the friendly string.
-# Exceptions prefix themselves with the PR they concern ("PR #9413: ..." or
-# "PR #9413 is too trivial: ..."), and the callers print the reason as "PR #N: {message}".
-# Stripping the self-prefix is what removes the doubled "PR #9413: PR #9413:".
+# Exceptions name the PR they concern ("PR #9413: ...", "PR #9413 is too trivial: ..."),
+# and callers print the reason as "PR #N: {message}". Strip the self-prefix so the PR is
+# named once.
 _SELF_PREFIX_RE = re.compile(r"^PR #\d+\b(?:\s+is)?\s*:?\s*", re.IGNORECASE)
 
+# Friendly label per category, paired with the phrase that means the exception's message
+# already conveys it. Categories reached only via _classify_failure are absent: for those
+# the message is already the friendly string.
 CATEGORY_LABELS = {
     "trivial": ("Trivial PR (skipped)", "trivial"),
     "no_issue": ("No linked issue (skipped)", "linked issue"),
@@ -185,9 +182,8 @@ CATEGORY_LABELS = {
 def _failure_message(pr_number: int, category: str | None, error_msg: str) -> str:
     """Render the human-facing reason for a failed PR.
 
-    Strips any leading "PR #N: " the exception prefixed itself with: the callers print
-    this as "PR #N: {message}", which is where the doubled "PR #9413: PR #9413:" in the
-    farm log came from.
+    Keeps the exception's detail ("Too many source files modified (14, max 10)"), which a
+    bare label drops, and prepends the label only when the detail does not already say it.
     """
     detail = _SELF_PREFIX_RE.sub("", (error_msg or "").replace("\n", " ").strip())
     if detail:
@@ -440,7 +436,7 @@ def _run_reversal_for_pr_impl(
         error_category = "already_exists"
         success = False
     except Exception as e:
-        # Unexpected error: nothing set a category for us, so sniff the message.
+        # Unexpected error: no handler set a category, so derive one from the message.
         error_msg = f"{type(e).__name__}: {str(e)}"
         if config.verbose:
             console.print(f"[red]{traceback.format_exc()}[/red]")
@@ -514,11 +510,10 @@ def _run_reversal_for_pr_impl(
             category=failure_category,
         )
 
-    # Pipeline failed. Trust the category the handler above already established -- do not
-    # re-derive it by grepping the message. _classify_failure only recognises a trivial PR
-    # by the literal word "trivial", so a TrivialPRError raised for the file-count bounds
-    # ("Too many source files modified (14, max 10)") was landing in "other": it delayed
-    # 60s before the next PR and was counted under Other Errors in the summary.
+    # Pipeline failed. Use the category the handler set; _classify_failure only sees the
+    # message text, and several of these (the file-count bounds, say) do not spell out
+    # which category they belong to. The category drives the inter-PR delay and the run
+    # summary's failure breakdown, so it has to be exact.
     failure_category = error_category
     failure_reason = _failure_message(pr.number, error_category, error_msg)
 

--- a/src/swegen/farm/farm_hand.py
+++ b/src/swegen/farm/farm_hand.py
@@ -174,19 +174,24 @@ _SELF_PREFIX_RE = re.compile(r"^PR #\d+\b(?:\s+is)?\s*:?\s*", re.IGNORECASE)
 CATEGORY_LABELS = {
     "trivial": ("Trivial PR (skipped)", "trivial"),
     "no_issue": ("No linked issue (skipped)", "linked issue"),
-    "validation_failed": ("Validation failed (NOP or Oracle)", "validation"),
+    # Not "(NOP or Oracle)": this category also covers the offline-tests policy and the
+    # task-structure checks. The Harbor message names NOP/Oracle itself when that is the
+    # cause, and the label is skipped whenever the detail already says "validation".
+    "validation_failed": ("Validation failed", "validation"),
     "already_exists": ("Task already exists (skipped)", "already exists"),
 }
 
 
-def _failure_message(pr_number: int, category: str | None, error_msg: str) -> str:
+def _failure_message(category: str | None, error_msg: str) -> str:
     """Render the human-facing reason for a failed PR.
 
     Keeps the exception's detail ("Too many source files modified (14, max 10)"), which a
     bare label drops, and prepends the label only when the detail does not already say it.
     """
-    detail = _SELF_PREFIX_RE.sub("", (error_msg or "").replace("\n", " ").strip())
-    if detail:
+    detail, stripped = _SELF_PREFIX_RE.subn("", (error_msg or "").replace("\n", " ").strip())
+    # Only re-capitalise what the strip decapitated ("PR #9413 is too trivial" ->
+    # "Too trivial"). Messages that start lowercase on their own may begin with a path.
+    if stripped and detail:
         detail = detail[0].upper() + detail[1:]
 
     label, spoken_for = CATEGORY_LABELS.get(category or "", (None, None))
@@ -515,7 +520,7 @@ def _run_reversal_for_pr_impl(
     # which category they belong to. The category drives the inter-PR delay and the run
     # summary's failure breakdown, so it has to be exact.
     failure_category = error_category
-    failure_reason = _failure_message(pr.number, error_category, error_msg)
+    failure_reason = _failure_message(error_category, error_msg)
 
     if failure_category == "publish_failed":
         # The task itself is valid - it passed every gate and only the push/PR failed.


### PR DESCRIPTION
Fixes the 60s wait still seen on cheaply-rejected PRs, reported on a live farm run
(`openms/openms#9413`), and keeps the failure reasons readable.

## The bug

Every exception handler in `_run_reversal_for_pr_impl` assigns an `error_category`
-- `TrivialPRError` sets `"trivial"`, `MissingIssueError` sets `"no_issue"`, and so
on. The final block then discarded it and re-derived the category by grepping the
exception message:

```python
failure_category, failure_reason = _classify_failure(error_msg)
```

`_classify_failure` only recognises a trivial PR by the literal word `"trivial"`.
But `TrivialPRError` is *also* raised for the source-file count bounds, whose
message reads:

> PR #9413: Too many source files modified (14, max 10) - likely a large refactor (tests excluded)

No `"trivial"` anywhere, so it fell through to the catch-all `"other"`. (Same for
the lower bound, `"Only 1 source file modified (min 3)"`.)

Two consequences:

1. **The 60s inter-PR delay came back.** `"other"` is not in `SKIPPED_CATEGORIES`,
   so the farm slept `task_delay` even though no Claude Code session ran.
2. **The run summary misreports** (pre-existing, independent of #59): these PRs
   were counted under "Other Errors" instead of "Trivial PRs".

## The fix

Use the category the handler set. Only derive one from the message for genuinely
unexpected exceptions, where no handler set one.

Failure reasons are then rendered rather than taken raw: the `PR #N:` prefix an
exception adds to its own message is stripped (callers already print
`PR #N: {message}`), and the friendly label is prepended only when the message does
not already convey it. That keeps the diagnostic detail a bare label would drop,
without the stutter a blanket label produces.

## Result

| category | printed reason |
|---|---|
| `trivial` | `PR #9413: Trivial PR (skipped): Too many source files modified (14, max 10) - likely a large refactor` |
| `trivial` | `PR #9413: Too trivial: docs only` |
| `no_issue` | `PR #9413: No linked issue found (use --no-require-issue to skip this check)` |
| `validation_failed` | `PR #9413: Harbor validation failed (NOP or Oracle did not pass)` |
| `rate_limited` | `PR #9413: Claude rate limit: usage limit reached` |
| `publish_failed` | `PR #9413: Publish failed: push rejected` |
| `already_exists` | `PR #9413: Task already exists: tasks/openms__openms-9413` |
| `git_error` | `PR #9413: Git checkout failed (repo cache may be corrupted)` |

## Verification

Drove the exact openms failure through `_process_pr` with `task_delay=60`:

| | before | after |
|---|---|---|
| category | `other` | `trivial` |
| elapsed | 60s | 0.00s |
| summary bucket | `other_failed_prs` | `trivial_prs` |

Also exercised every failure category end-to-end, confirming each maps correctly,
that unexpected errors are still classified from their message
(`RuntimeError("git checkout failed")` -> `git_error`), and that `publish_failed`
remains the only category that preserves the task directory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to farm failure reporting and classification; no auth, data, or pipeline execution path changes beyond correct category/delay behavior.
> 
> **Overview**
> Fixes farm runs **sleeping the full inter-PR delay** and **mis-bucketing cheap rejections** when a handler already knew the failure type but the pipeline threw that away and re-derived category from the exception text.
> 
> On failure, **`_run_reversal_for_pr_impl` now keeps the `error_category` set by each exception handler** instead of calling `_classify_failure(error_msg)` at the end. Message-only classification remains **only for unexpected exceptions**, where `_classify_failure` also normalizes the message.
> 
> Adds **`_failure_message`**: strips redundant `PR #N:` prefixes from exception text and prepends friendly category labels only when the detail does not already convey them, so logs and run summaries keep specifics (e.g. file-count bounds) without duplicate PR IDs or stuttered labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89f47fa84d711c18be7c2b9c3cc802ee23923827. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->