### PR TITLE
feat(farm): record a run report on every exit, pushed to the state branch

### DIFF
--- a/src/swegen/farm/fetcher.py
+++ b/src/swegen/farm/fetcher.py
@@ -94,10 +94,9 @@ class StreamingPRFetcher:
         self.min_files = min_files
         self.require_tests = require_tests
         self.api_delay = api_delay
-        # Why the stream stopped early, or None if it ran to genuine exhaustion. The loop
-        # SWALLOWS a page-fetch error and breaks, which is indistinguishable from "no more
-        # PRs" to the caller - so a GitHub 5xx would otherwise be reported as a clean
-        # finish. The farmer reads this to tell the two apart in its run report.
+        # Why the stream stopped early, or None if the PR history ran out. The loop ends
+        # the generator identically in both cases, so the farmer reads this to tell an API
+        # failure apart from genuine exhaustion.
         self.stop_reason: str | None = None
 
         # GitHub API setup
@@ -182,9 +181,6 @@ class StreamingPRFetcher:
             except requests.exceptions.RequestException as exc:
                 self.console.print(f"[red]API error on page {page}: {exc}[/red]")
                 skipped_stats["api_error"] += 1
-                # Record WHY we are giving up. Breaking here ends the generator exactly as
-                # exhaustion would, so without this the farmer cannot tell a GitHub outage
-                # from "no PRs left" and would file the run as completed.
                 self.stop_reason = f"GitHub API error on page {page}: {exc}"
                 break
 

--- a/src/swegen/farm/fetcher.py
+++ b/src/swegen/farm/fetcher.py
@@ -94,6 +94,11 @@ class StreamingPRFetcher:
         self.min_files = min_files
         self.require_tests = require_tests
         self.api_delay = api_delay
+        # Why the stream stopped early, or None if it ran to genuine exhaustion. The loop
+        # SWALLOWS a page-fetch error and breaks, which is indistinguishable from "no more
+        # PRs" to the caller - so a GitHub 5xx would otherwise be reported as a clean
+        # finish. The farmer reads this to tell the two apart in its run report.
+        self.stop_reason: str | None = None
 
         # GitHub API setup
         self.api_base = "https://api.github.com"
@@ -177,6 +182,10 @@ class StreamingPRFetcher:
             except requests.exceptions.RequestException as exc:
                 self.console.print(f"[red]API error on page {page}: {exc}[/red]")
                 skipped_stats["api_error"] += 1
+                # Record WHY we are giving up. Breaking here ends the generator exactly as
+                # exhaustion would, so without this the farmer cannot tell a GitHub outage
+                # from "no PRs left" and would file the run as completed.
+                self.stop_reason = f"GitHub API error on page {page}: {exc}"
                 break
 
             prs = resp.json()

--- a/src/swegen/farm/state.py
+++ b/src/swegen/farm/state.py
@@ -6,6 +6,17 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 
+def _report_time(report: dict | None) -> str:
+    """When a run report was last meaningful: its end, or its start if still in flight.
+
+    Used to pick between two reports on merge. Empty string for a missing report, so any
+    real report beats none.
+    """
+    if not report:
+        return ""
+    return report.get("ended_at") or report.get("started_at") or ""
+
+
 @dataclass
 class StreamState:
     """State for resumable streaming PR processing.
@@ -321,8 +332,13 @@ class StreamState:
         self.processed_prs -= self.publish_failed_prs | self.claude_rate_limited_prs
 
         self.total_fetched = max(self.total_fetched, other.total_fetched)
-        # Receiver is the fresher state, so its run report wins; fall back to the other's.
-        if self.last_run is None:
+        # Keep the more recent run report rather than always the receiver's. After startup
+        # the receiver ALWAYS has one (at least "running"), so "receiver wins" would discard
+        # the remote report unconditionally - including a terminal outcome another writer
+        # just published, replacing a death certificate with a mid-run "running" marker.
+        # A report is timestamped by when it ended, or by when its run began if it is still
+        # in flight; the later of the two survives.
+        if _report_time(other.last_run) > _report_time(self.last_run):
             self.last_run = other.last_run
         if other.last_created_at and (
             not self.last_created_at or other.last_created_at > self.last_created_at

--- a/src/swegen/farm/state.py
+++ b/src/swegen/farm/state.py
@@ -9,8 +9,7 @@ from pathlib import Path
 def _report_time(report: dict | None) -> str:
     """When a run report was last meaningful: its end, or its start if still in flight.
 
-    Used to pick between two reports on merge. Empty string for a missing report, so any
-    real report beats none.
+    Empty string for a missing report, so any real report sorts above none.
     """
     if not report:
         return ""
@@ -61,10 +60,8 @@ class StreamState:
     last_pr_number: int | None = None
     last_created_at: str | None = None
     last_updated: str | None = None
-    # Death certificate for the most recent run: why it stopped. Written on every exit
-    # path (completed / aborted / crashed / interrupted) and pushed with the state, so a
-    # reclaimed sandbox still leaves an explanation behind. Without it, a crash and a
-    # clean completion are indistinguishable - the state simply stops advancing.
+    # Report for the most recent run: why it stopped. Written on every exit path and
+    # pushed with the state, so a reclaimed sandbox still leaves an explanation behind.
     last_run: dict | None = None
     skip_list_prs: set[int] = None
     
@@ -332,12 +329,8 @@ class StreamState:
         self.processed_prs -= self.publish_failed_prs | self.claude_rate_limited_prs
 
         self.total_fetched = max(self.total_fetched, other.total_fetched)
-        # Keep the more recent run report rather than always the receiver's. After startup
-        # the receiver ALWAYS has one (at least "running"), so "receiver wins" would discard
-        # the remote report unconditionally - including a terminal outcome another writer
-        # just published, replacing a death certificate with a mid-run "running" marker.
-        # A report is timestamped by when it ended, or by when its run began if it is still
-        # in flight; the later of the two survives.
+        # The later report wins, so a terminal outcome is not replaced by an in-flight
+        # marker from a run that started earlier.
         if _report_time(other.last_run) > _report_time(self.last_run):
             self.last_run = other.last_run
         if other.last_created_at and (

--- a/src/swegen/farm/state.py
+++ b/src/swegen/farm/state.py
@@ -50,6 +50,11 @@ class StreamState:
     last_pr_number: int | None = None
     last_created_at: str | None = None
     last_updated: str | None = None
+    # Death certificate for the most recent run: why it stopped. Written on every exit
+    # path (completed / aborted / crashed / interrupted) and pushed with the state, so a
+    # reclaimed sandbox still leaves an explanation behind. Without it, a crash and a
+    # clean completion are indistinguishable - the state simply stops advancing.
+    last_run: dict | None = None
     skip_list_prs: set[int] = None
     
     # Detailed categorization
@@ -316,6 +321,9 @@ class StreamState:
         self.processed_prs -= self.publish_failed_prs | self.claude_rate_limited_prs
 
         self.total_fetched = max(self.total_fetched, other.total_fetched)
+        # Receiver is the fresher state, so its run report wins; fall back to the other's.
+        if self.last_run is None:
+            self.last_run = other.last_run
         if other.last_created_at and (
             not self.last_created_at or other.last_created_at > self.last_created_at
         ):
@@ -337,6 +345,7 @@ class StreamState:
             "last_pr_number": self.last_pr_number,
             "last_created_at": self.last_created_at,
             "last_updated": self.last_updated,
+            "last_run": self.last_run,
             # Detailed breakdown
             "successful_prs": {str(k): v for k, v in self.successful_prs.items()},
             "task_pr_urls": {str(k): v for k, v in self.task_pr_urls.items()},
@@ -378,6 +387,7 @@ class StreamState:
             last_pr_number=data.get("last_pr_number"),
             last_created_at=data.get("last_created_at"),
             last_updated=data.get("last_updated"),
+            last_run=data.get("last_run"),
             # Detailed breakdown
             successful_prs={int(k): v for k, v in data.get("successful_prs", {}).items()},
             task_pr_urls={int(k): v for k, v in data.get("task_pr_urls", {}).items()},

--- a/src/swegen/farm/stream_farm.py
+++ b/src/swegen/farm/stream_farm.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import json
+import os
+import platform
 import shutil
 import signal
 import subprocess
 import time
+import traceback
 from dataclasses import asdict
 from datetime import UTC, datetime
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from pathlib import Path
 
 from rich.console import Console
@@ -34,6 +39,11 @@ from .state import StreamState
 # runtimes) or any unrelated image on the host, both of which `docker system prune -af`
 # would happily delete.
 HARBOR_IMAGE_GLOB = "hb__*"
+
+# The run report is committed to the state branch, so every free-text field is capped.
+_TRACEBACK_TAIL_LINES = 40
+_DETAIL_MAX_CHARS = 2000
+_MESSAGE_MAX_CHARS = 500
 
 
 def docker_cleanup_cmds(build_cache_keep: str) -> list[str]:
@@ -168,6 +178,13 @@ class StreamFarmer:
         # driving the prune/progress cadence off a counter that never moves would fire
         # them on every iteration.
         self.prs_seen = 0
+
+        # Run-report bookkeeping. current_pr is set only while a PR is in flight: on a
+        # crash, its absence says we died BETWEEN PRs, which points at the fetcher rather
+        # than at task generation.
+        self.run_started_at = _now_utc()
+        self.current_pr: int | None = None
+
         signal.signal(signal.SIGINT, self._handle_shutdown)
         signal.signal(signal.SIGTERM, self._handle_shutdown)
 
@@ -222,23 +239,175 @@ class StreamFarmer:
     def run(self) -> int:
         """Run the continuous farming process.
 
+        Every exit path records a run report (a "death certificate") into the state before
+        _finalize() pushes it, so the state branch always explains why the run stopped.
+        Without it a crash and a clean completion are indistinguishable - the state simply
+        stops advancing, which is useless when the sandbox that held the traceback is gone.
+
         Returns:
-            Exit code: 0 if any tasks succeeded, 1 otherwise. Aborting because publishing
-            broke is always a failure, even if earlier tasks published fine.
+            Exit code: 0 only on a clean run that produced tasks. Aborting (publish/state
+            failure, Claude rate limit) or crashing is always 1.
         """
         self._print_header()
 
-        # Start streaming and processing
+        # Mark the run as in-flight and push it. This is what makes a SILENT death
+        # detectable: if the sandbox is OOM-killed or reclaimed, nothing overwrites this,
+        # so the state branch is left saying outcome="running" with a stale timestamp -
+        # which is exactly the signature of "killed without getting to report".
+        self._record_outcome("running", "Run in progress")
+        self._save_state()
+
         try:
             self._run_stream()
+            if not self.aborted and not self.shutdown_requested:
+                # The stream ended on its own: no more candidate PRs upstream.
+                self._record_outcome("completed", "PR stream exhausted")
         except KeyboardInterrupt:
             self.console.print("\n[yellow]Interrupted by user[/yellow]")
+            self._record_outcome("interrupted", "Interrupted by user (SIGINT)")
+        except Exception as e:
+            # Anything the per-PR handler did not already catch - most commonly the
+            # StreamingPRFetcher raising while fetching the next page (GitHub 5xx, network,
+            # rate limit). Previously this escaped run() as a raw traceback, so the state
+            # branch showed a healthy run that simply stopped, and the only explanation
+            # died with the sandbox.
+            self._record_crash(e)
         finally:
+            # Pushes the state, run report included.
             self._finalize()
 
         if self.aborted:
             return 1
         return 0 if self.state.successful > 0 else 1
+
+    def _recent_results(self, limit: int = 5) -> list[dict]:
+        """The last few PR outcomes, for context on what the farm was doing when it died."""
+        recent = []
+        for r in self.results[-limit:]:
+            entry = {"pr": r.pr_number, "status": r.status, "category": r.category}
+            if r.message:
+                entry["message"] = r.message[:_MESSAGE_MAX_CHARS]
+            if r.pr_url:
+                entry["pr_url"] = r.pr_url
+            recent.append(entry)
+        return recent
+
+    def _environment_report(self) -> dict:
+        """Host / version / config context. All of it is needed to reproduce a crash."""
+
+        def _ver(pkg: str) -> str | None:
+            try:
+                return _pkg_version(pkg)
+            except PackageNotFoundError:
+                return None
+
+        pub = self.config.publish
+        return {
+            "host": platform.node(),
+            # Set by Daytona inside the sandbox; lets a report be tied back to a container.
+            "sandbox_id": os.environ.get("DAYTONA_SANDBOX_ID"),
+            "versions": {
+                "swegen": _ver("swe-gen"),
+                "claude_agent_sdk": _ver("claude-agent-sdk"),
+                "harbor": _ver("harbor"),
+                "python": platform.python_version(),
+            },
+            "config": {
+                "environment": str(self.config.environment),
+                "cc_timeout": self.config.cc_timeout,
+                "require_issue": self.config.require_issue,
+                "docker_prune_batch": self.config.docker_prune_batch,
+                "publish_repo": pub.repo if pub else None,
+                "cleanup_local": pub.cleanup_local if pub else None,
+                "dry_run": self.config.dry_run,
+            },
+        }
+
+    def _record_outcome(
+        self,
+        outcome: str,
+        reason: str,
+        detail: str | None = None,
+        error_type: str | None = None,
+        traceback_tail: str | None = None,
+    ) -> None:
+        """Write the run report into the state, to be pushed on the next save.
+
+        outcome: running | completed | aborted | crashed | interrupted
+
+        Deliberately verbose: this is committed to the state branch and is often the ONLY
+        surviving evidence once an ephemeral sandbox is gone. It stays bounded (a capped
+        traceback tail, the last few results) so the branch does not bloat, and it is only
+        written on run start and run exit - not per PR.
+        """
+        now = _now_utc()
+        report: dict = {
+            "outcome": outcome,
+            "reason": reason,
+            "started_at": self.run_started_at.isoformat(),
+            "ended_at": now.isoformat() if outcome != "running" else None,
+            "duration_seconds": round((now - self.run_started_at).total_seconds(), 1),
+            "prs_seen_this_run": self.prs_seen,
+            # Set only while a PR is in flight. Its ABSENCE on a crash is itself a clue: we
+            # died between PRs, which points at the fetcher rather than task generation.
+            "pr_in_flight": self.current_pr,
+            "last_pr_number": self.state.last_pr_number,
+            "last_created_at": self.state.last_created_at,
+            "counters": {
+                "successful": self.state.successful,
+                "failed": self.state.failed,
+                "total_processed": self.state.total_processed,
+            },
+            "pending_retry": {
+                "publish_failed": sorted(self.state.publish_failed_prs),
+                "claude_rate_limited": sorted(self.state.claude_rate_limited_prs),
+            },
+            "recent_results": self._recent_results(),
+            "environment": self._environment_report(),
+        }
+        if detail:
+            report["detail"] = detail[:_DETAIL_MAX_CHARS]
+        if error_type:
+            report["error_type"] = error_type
+        if traceback_tail:
+            report["traceback"] = traceback_tail
+        self.state.last_run = report
+
+    def _record_crash(self, exc: BaseException) -> None:
+        """Record an unhandled exception and show it, instead of dying with a bare trace."""
+        tb = traceback.format_exc()
+        # Keep the tail: the frames nearest the failure are the informative ones, and the
+        # report is committed to a git branch, so it must stay bounded. format_exc()
+        # includes chained causes ("during handling of...", "caused by"), which we want.
+        tail = "\n".join(tb.strip().splitlines()[-_TRACEBACK_TAIL_LINES:])
+
+        self.aborted = True
+        self.shutdown_requested = True
+        self._record_outcome(
+            "crashed",
+            f"{type(exc).__name__}: {exc}",
+            error_type=type(exc).__name__,
+            traceback_tail=tail,
+        )
+
+        where = (
+            f"while processing PR #{self.current_pr}"
+            if self.current_pr is not None
+            else "between PRs (most likely fetching the next page of PRs)"
+        )
+        self.console.print(
+            Panel(
+                Text(
+                    f"{type(exc).__name__}: {exc}\n\n"
+                    f"Crashed {where}.\n"
+                    f"The run report is being pushed to the state branch, so this is "
+                    f"recoverable even if the sandbox is reclaimed.\n\n{tail}",
+                    style="red",
+                ),
+                title="[red]Farm crashed[/red]",
+                border_style="red",
+            )
+        )
 
     def _print_header(self) -> None:
         """Print the farming header with settings."""
@@ -292,7 +461,12 @@ class StreamFarmer:
         # disk. Republish it instead of regenerating - force=True would delete it first.
         publish_only = pr.number in self.state.publish_failed_prs
 
-        # Process this PR completely before moving to next
+        # Held for the duration of this PR, and deliberately NOT cleared in a finally: if we
+        # crash here it must survive into the run report. Cleared only once the PR is fully
+        # handled (see the end of this method), so a crash with pr_in_flight=None means we
+        # died between PRs - which points at the fetcher rather than at task generation.
+        self.current_pr = pr.number
+
         result = _run_reversal_for_pr(
             pr, self.config, self.tasks_root, self.console, publish_only=publish_only
         )
@@ -344,9 +518,14 @@ class StreamFarmer:
 
         # A publish failure or a failed state push ends the run. Checked together: both can
         # fail in the same iteration, and reporting only the first would tell the operator
-        # farm state was preserved when it was not.
+        # farm state was preserved when it was not. current_pr stays set here on purpose:
+        # the abort report should name the PR we stopped on.
         if self._check_publish_health(result, state_saved):
             return
+
+        # This PR is fully handled. Anything that crashes from here to the next PR is the
+        # fetcher's, and the report will say pr_in_flight=None.
+        self.current_pr = None
 
         # Rate limit protection: only sleep after PRs that actually ran a CC session
         if not self._should_delay_after(result):
@@ -383,6 +562,11 @@ class StreamFarmer:
         """
         self.aborted = True
         self.shutdown_requested = True
+
+        # Land the reason in the run report too, so the state branch explains the abort
+        # without anyone needing the console output (which dies with the sandbox).
+        self._record_outcome("aborted", reason, detail=detail or None)
+
         body = reason
         if detail:
             body += f"\n\n{detail}"

--- a/src/swegen/farm/stream_farm.py
+++ b/src/swegen/farm/stream_farm.py
@@ -44,6 +44,7 @@ HARBOR_IMAGE_GLOB = "hb__*"
 _TRACEBACK_TAIL_LINES = 40
 _DETAIL_MAX_CHARS = 2000
 _MESSAGE_MAX_CHARS = 500
+_REASON_MAX_CHARS = 1000
 
 
 def docker_cleanup_cmds(build_cache_keep: str) -> list[str]:
@@ -259,9 +260,7 @@ class StreamFarmer:
 
         try:
             self._run_stream()
-            if not self.aborted and not self.shutdown_requested:
-                # The stream ended on its own: no more candidate PRs upstream.
-                self._record_outcome("completed", "PR stream exhausted")
+            self._record_stream_end()
         except KeyboardInterrupt:
             self.console.print("\n[yellow]Interrupted by user[/yellow]")
             self._record_outcome("interrupted", "Interrupted by user (SIGINT)")
@@ -279,6 +278,47 @@ class StreamFarmer:
         if self.aborted:
             return 1
         return 0 if self.state.successful > 0 else 1
+
+    def _record_stream_end(self) -> None:
+        """Classify a stream that ended without raising. Three very different things.
+
+        The generator returns identically whether it ran out of PRs, gave up on a GitHub
+        API error, or was cut short by a shutdown signal - so each has to be teased apart
+        explicitly, or a farm killed by a GitHub outage gets filed as a clean finish.
+        """
+        if self.aborted:
+            # _abort() already wrote the report, with its own reason.
+            return
+
+        if self.shutdown_requested:
+            # SIGINT/SIGTERM. _handle_shutdown only sets a flag - it never raises - so the
+            # KeyboardInterrupt branch in run() does NOT fire for a signal, and without
+            # this the report would be left saying "running": the silent-kill signature.
+            # SIGTERM is exactly what a sandbox stop sends, so this must not look like a
+            # crash.
+            self._record_outcome("interrupted", "Shutdown requested (SIGINT/SIGTERM)")
+            return
+
+        if self.fetcher.stop_reason:
+            # The fetcher swallowed a page-fetch error and broke out. Not exhaustion, and
+            # not a crash: the run stopped early and should be retried.
+            self.aborted = True  # exit 1: this run did not finish its work
+            self._record_outcome("stream_failed", self.fetcher.stop_reason)
+            self.console.print(
+                Panel(
+                    Text(
+                        f"{self.fetcher.stop_reason}\n\n"
+                        f"The PR stream stopped early - this is NOT an exhausted history. "
+                        f"Re-run to continue from the cursor.",
+                        style="red",
+                    ),
+                    title="[red]Stopping: PR stream failed[/red]",
+                    border_style="red",
+                )
+            )
+            return
+
+        self._record_outcome("completed", "PR stream exhausted")
 
     def _recent_results(self, limit: int = 5) -> list[dict]:
         """The last few PR outcomes, for context on what the farm was doing when it died."""
@@ -307,7 +347,7 @@ class StreamFarmer:
             # Set by Daytona inside the sandbox; lets a report be tied back to a container.
             "sandbox_id": os.environ.get("DAYTONA_SANDBOX_ID"),
             "versions": {
-                "swegen": _ver("swe-gen"),
+                "swegen": _ver("swegen"),
                 "claude_agent_sdk": _ver("claude-agent-sdk"),
                 "harbor": _ver("harbor"),
                 "python": platform.python_version(),
@@ -343,7 +383,7 @@ class StreamFarmer:
         now = _now_utc()
         report: dict = {
             "outcome": outcome,
-            "reason": reason,
+            "reason": reason[:_REASON_MAX_CHARS],
             "started_at": self.run_started_at.isoformat(),
             "ended_at": now.isoformat() if outcome != "running" else None,
             "duration_seconds": round((now - self.run_started_at).total_seconds(), 1),

--- a/src/swegen/farm/stream_farm.py
+++ b/src/swegen/farm/stream_farm.py
@@ -261,7 +261,11 @@ class StreamFarmer:
         # so the state branch is left saying outcome="running" with a stale timestamp -
         # which is exactly the signature of "killed without getting to report".
         self._record_outcome("running", "Run in progress")
-        if not self._save_state():
+        # Retried, like the final save: a transient blip here should not stop a run before
+        # it starts, and aborting only once the retries are spent keeps `state_saved=False`
+        # honest - otherwise the panel would claim the branch was never written while
+        # _finalize quietly recovered it on retry.
+        if not self._save_state_with_retry():
             # The state branch is unwritable (bad token, branch protection, GitHub down).
             # Stop NOW rather than farming: the first PR would spend a full Claude Code
             # session and only then hit the same failure in _process_pr and abort anyway.
@@ -274,7 +278,7 @@ class StreamFarmer:
                 "PR just to fail at the same wall.",
                 state_saved=False,
             )
-            self._finalize()
+            self._save_log()
             return 1
 
         try:
@@ -848,27 +852,11 @@ class StreamFarmer:
             self.console.print(
                 "[red]Final state push failed after "
                 f"{_FINAL_SAVE_ATTEMPTS} attempts - the durable cursor is stale and the "
-                "state branch still says 'running'. The full run report IS in the local "
-                f"mirror ({self.state_file}); recover it before this sandbox is "
-                "reclaimed.[/red]"
+                "state branch did not receive this run's report (so it still shows whatever "
+                "it last held: the 'running' marker, or a previous run's outcome). The full "
+                f"report IS in the local mirror ({self.state_file}); recover it before this "
+                "sandbox is reclaimed.[/red]"
             )
-        self._save_log()
-
-    def _save_state_with_retry(self) -> bool:
-        """Save the state, retrying a transient push failure with backoff."""
-        for attempt in range(1, _FINAL_SAVE_ATTEMPTS + 1):
-            if self._save_state():
-                return True
-            if attempt == _FINAL_SAVE_ATTEMPTS:
-                break
-            delay = _FINAL_SAVE_BACKOFF_SECONDS * attempt
-            self.console.print(
-                f"[yellow]State push failed; retrying in {delay:.0f}s "
-                f"(attempt {attempt}/{_FINAL_SAVE_ATTEMPTS})[/yellow]"
-            )
-            time.sleep(delay)
-        return False
-
         self.console.print("\n")
         self.console.print(Rule(Text("Final Summary", style="bold magenta")))
 
@@ -925,6 +913,23 @@ class StreamFarmer:
         log_path = self._get_log_path()
         self.console.print(f"\n[dim]Detailed log: {log_path}[/dim]")
         self.console.print(f"[dim]State saved: {self.state_file}[/dim]")
+        self._save_log()
+
+    def _save_state_with_retry(self) -> bool:
+        """Save the state, retrying a transient push failure with backoff."""
+        for attempt in range(1, _FINAL_SAVE_ATTEMPTS + 1):
+            if self._save_state():
+                return True
+            if attempt == _FINAL_SAVE_ATTEMPTS:
+                break
+            delay = _FINAL_SAVE_BACKOFF_SECONDS * attempt
+            self.console.print(
+                f"[yellow]State push failed; retrying in {delay:.0f}s "
+                f"(attempt {attempt}/{_FINAL_SAVE_ATTEMPTS})[/yellow]"
+            )
+            time.sleep(delay)
+        return False
+
 
     def _save_log(self) -> None:
         """Save results log to file."""

--- a/src/swegen/farm/stream_farm.py
+++ b/src/swegen/farm/stream_farm.py
@@ -256,7 +256,21 @@ class StreamFarmer:
         # so the state branch is left saying outcome="running" with a stale timestamp -
         # which is exactly the signature of "killed without getting to report".
         self._record_outcome("running", "Run in progress")
-        self._save_state()
+        if not self._save_state():
+            # The state branch is unwritable (bad token, branch protection, GitHub down).
+            # Stop NOW rather than farming: the first PR would spend a full Claude Code
+            # session and only then hit the same failure in _process_pr and abort anyway.
+            # Failing here costs zero sessions. The report still reaches the local mirror,
+            # which GitStateStore writes before it pushes.
+            self._abort(
+                "Farm state could not be pushed to the state branch at startup.",
+                "Nothing has been farmed yet. Fix the token or GitHub connectivity and "
+                "re-run - stopping here avoids burning a Claude Code session on the first "
+                "PR just to fail at the same wall.",
+                state_saved=False,
+            )
+            self._finalize()
+            return 1
 
         try:
             self._run_stream()

--- a/src/swegen/farm/stream_farm.py
+++ b/src/swegen/farm/stream_farm.py
@@ -46,8 +46,7 @@ _DETAIL_MAX_CHARS = 2000
 _MESSAGE_MAX_CHARS = 500
 _REASON_MAX_CHARS = 1000
 
-# The final save carries the run report. If it never lands, the branch keeps the "running"
-# marker and a crashed run is indistinguishable from an OOM kill - so retry it.
+# The startup and final saves carry the run report; retry a transient push failure.
 _FINAL_SAVE_ATTEMPTS = 3
 _FINAL_SAVE_BACKOFF_SECONDS = 3.0
 
@@ -185,9 +184,7 @@ class StreamFarmer:
         # them on every iteration.
         self.prs_seen = 0
 
-        # Run-report bookkeeping. current_pr is set only while a PR is in flight: on a
-        # crash, its absence says we died BETWEEN PRs, which points at the fetcher rather
-        # than at task generation.
+        # current_pr is set only while a PR is in flight, so a crash report can name it.
         self.run_started_at = _now_utc()
         self.current_pr: int | None = None
 
@@ -245,37 +242,26 @@ class StreamFarmer:
     def run(self) -> int:
         """Run the continuous farming process.
 
-        Every exit path records a run report (a "death certificate") into the state before
-        _finalize() pushes it, so the state branch always explains why the run stopped.
-        Without it a crash and a clean completion are indistinguishable - the state simply
-        stops advancing, which is useless when the sandbox that held the traceback is gone.
+        Every exit path records a run report into the state, which _finalize() pushes, so
+        the state branch always says why the run stopped.
 
         Returns:
-            Exit code: 0 only on a clean run that produced tasks. Aborting (publish/state
-            failure, Claude rate limit) or crashing is always 1.
+            Exit code: 0 only on a clean run that produced tasks; 1 on abort or crash.
         """
         self._print_header()
 
-        # Mark the run as in-flight and push it. This is what makes a SILENT death
-        # detectable: if the sandbox is OOM-killed or reclaimed, nothing overwrites this,
-        # so the state branch is left saying outcome="running" with a stale timestamp -
-        # which is exactly the signature of "killed without getting to report".
+        # An in-flight marker, pushed before any work. Nothing overwrites it if the process
+        # is killed outright, so a report left at outcome="running" means the run never got
+        # to report an exit.
         self._record_outcome("running", "Run in progress")
-        # Retried, like the final save: a transient blip here should not stop a run before
-        # it starts, and aborting only once the retries are spent keeps `state_saved=False`
-        # honest - otherwise the panel would claim the branch was never written while
-        # _finalize quietly recovered it on retry.
         if not self._save_state_with_retry():
-            # The state branch is unwritable (bad token, branch protection, GitHub down).
-            # Stop NOW rather than farming: the first PR would spend a full Claude Code
-            # session and only then hit the same failure in _process_pr and abort anyway.
-            # Failing here costs zero sessions. The report still reaches the local mirror,
-            # which GitStateStore writes before it pushes.
+            # The state branch is unwritable. Stop before farming: a resumed sandbox depends
+            # on the branch, and the first PR would spend a full Claude Code session only to
+            # hit the same failure in _process_pr. The report still reaches the local mirror.
             self._abort(
                 "Farm state could not be pushed to the state branch at startup.",
                 "Nothing has been farmed yet. Fix the token or GitHub connectivity and "
-                "re-run - stopping here avoids burning a Claude Code session on the first "
-                "PR just to fail at the same wall.",
+                "re-run.",
                 state_saved=False,
             )
             self._save_log()
@@ -288,14 +274,10 @@ class StreamFarmer:
             self.console.print("\n[yellow]Interrupted by user[/yellow]")
             self._record_outcome("interrupted", "Interrupted by user (SIGINT)")
         except Exception as e:
-            # Anything the per-PR handler did not already catch - most commonly the
-            # StreamingPRFetcher raising while fetching the next page (GitHub 5xx, network,
-            # rate limit). Previously this escaped run() as a raw traceback, so the state
-            # branch showed a healthy run that simply stopped, and the only explanation
-            # died with the sandbox.
+            # Whatever the per-PR handler did not catch, typically the fetcher raising
+            # between PRs.
             self._record_crash(e)
         finally:
-            # Pushes the state, run report included.
             self._finalize()
 
         if self.aborted:
@@ -303,25 +285,20 @@ class StreamFarmer:
         return 0 if self.state.successful > 0 else 1
 
     def _record_stream_end(self) -> None:
-        """Classify a stream that ended without raising. Three very different things.
+        """Classify a stream that ended without raising.
 
-        The generator returns identically whether it ran out of PRs, gave up on a GitHub
-        API error, or was cut short by a shutdown signal - so each has to be teased apart
-        explicitly, or a farm killed by a GitHub outage gets filed as a clean finish.
+        The generator returns identically whether the PR history ran out, the fetcher gave
+        up on an API error, or a shutdown signal cut the loop short, so each is teased apart
+        here.
         """
         if self.aborted:
-            # _abort() already wrote the report, with its own reason.
+            # _abort() already recorded the outcome.
             return
 
-        # stop_reason is checked BEFORE shutdown_requested on purpose. A signal can arrive
-        # while a page fetch is failing, and the API failure is the substantive cause: it is
-        # what a re-run has to overcome. Checking the signal first would drop stop_reason
-        # AND file the run as `interrupted`, which does not set aborted - so run() could
-        # return 0 on a stream failure, reporting a broken run as a healthy one.
+        # A stream failure outranks a signal: it is the condition a re-run has to overcome,
+        # and unlike `interrupted` it sets aborted, so the run exits non-zero.
         if self.fetcher.stop_reason:
-            # The fetcher gave up on a page fetch and broke out. Not exhaustion, and not a
-            # crash: the run stopped early and should be retried.
-            self.aborted = True  # exit 1: this run did not finish its work
+            self.aborted = True
             reason = self.fetcher.stop_reason
             if self.shutdown_requested:
                 reason = f"{reason} (a shutdown signal also arrived)"
@@ -340,19 +317,16 @@ class StreamFarmer:
             )
             return
 
+        # _handle_shutdown only sets a flag, so a signal never raises KeyboardInterrupt and
+        # has to be recognised here.
         if self.shutdown_requested:
-            # SIGINT/SIGTERM. _handle_shutdown only sets a flag - it never raises - so the
-            # KeyboardInterrupt branch in run() does NOT fire for a signal, and without
-            # this the report would be left saying "running": the silent-kill signature.
-            # SIGTERM is exactly what a sandbox stop sends, so this must not look like a
-            # crash.
             self._record_outcome("interrupted", "Shutdown requested (SIGINT/SIGTERM)")
             return
 
         self._record_outcome("completed", "PR stream exhausted")
 
     def _recent_results(self, limit: int = 5) -> list[dict]:
-        """The last few PR outcomes, for context on what the farm was doing when it died."""
+        """The last few PR outcomes, for context on what the run was doing when it stopped."""
         recent = []
         for r in self.results[-limit:]:
             entry = {"pr": r.pr_number, "status": r.status, "category": r.category}
@@ -364,7 +338,7 @@ class StreamFarmer:
         return recent
 
     def _environment_report(self) -> dict:
-        """Host / version / config context. All of it is needed to reproduce a crash."""
+        """Host, version and config context needed to reproduce a failure."""
 
         def _ver(pkg: str) -> str | None:
             try:
@@ -375,7 +349,7 @@ class StreamFarmer:
         pub = self.config.publish
         return {
             "host": platform.node(),
-            # Set by Daytona inside the sandbox; lets a report be tied back to a container.
+            # Set by Daytona inside the sandbox; ties a report back to its container.
             "sandbox_id": os.environ.get("DAYTONA_SANDBOX_ID"),
             "versions": {
                 "swegen": _ver("swegen"),
@@ -404,12 +378,11 @@ class StreamFarmer:
     ) -> None:
         """Write the run report into the state, to be pushed on the next save.
 
-        outcome: running | completed | aborted | crashed | interrupted
+        outcome: running | completed | aborted | crashed | interrupted | stream_failed
 
-        Deliberately verbose: this is committed to the state branch and is often the ONLY
-        surviving evidence once an ephemeral sandbox is gone. It stays bounded (a capped
-        traceback tail, the last few results) so the branch does not bloat, and it is only
-        written on run start and run exit - not per PR.
+        This is often the only surviving evidence once an ephemeral sandbox is gone, so it
+        is detailed - but bounded (capped free text, the last few results) and written only
+        on run start and run exit, not per PR.
         """
         now = _now_utc()
         report: dict = {
@@ -419,8 +392,8 @@ class StreamFarmer:
             "ended_at": now.isoformat() if outcome != "running" else None,
             "duration_seconds": round((now - self.run_started_at).total_seconds(), 1),
             "prs_seen_this_run": self.prs_seen,
-            # Set only while a PR is in flight. Its ABSENCE on a crash is itself a clue: we
-            # died between PRs, which points at the fetcher rather than task generation.
+            # Set only while a PR is in flight; null on a crash means the failure happened
+            # between PRs, i.e. in the fetcher rather than in task generation.
             "pr_in_flight": self.current_pr,
             "last_pr_number": self.state.last_pr_number,
             "last_created_at": self.state.last_created_at,
@@ -445,11 +418,10 @@ class StreamFarmer:
         self.state.last_run = report
 
     def _record_crash(self, exc: BaseException) -> None:
-        """Record an unhandled exception and show it, instead of dying with a bare trace."""
+        """Record an unhandled exception and show it, rather than exiting with a bare trace."""
         tb = traceback.format_exc()
-        # Keep the tail: the frames nearest the failure are the informative ones, and the
-        # report is committed to a git branch, so it must stay bounded. format_exc()
-        # includes chained causes ("during handling of...", "caused by"), which we want.
+        # The tail holds the frames nearest the failure, and any chained cause. Bounded
+        # because the report is committed to a git branch.
         tail = "\n".join(tb.strip().splitlines()[-_TRACEBACK_TAIL_LINES:])
 
         self.aborted = True
@@ -532,10 +504,8 @@ class StreamFarmer:
         # disk. Republish it instead of regenerating - force=True would delete it first.
         publish_only = pr.number in self.state.publish_failed_prs
 
-        # Held for the duration of this PR, and deliberately NOT cleared in a finally: if we
-        # crash here it must survive into the run report. Cleared only once the PR is fully
-        # handled (see the end of this method), so a crash with pr_in_flight=None means we
-        # died between PRs - which points at the fetcher rather than at task generation.
+        # Not cleared in a finally: a crash here must leave this set so the run report can
+        # name the PR. Cleared once the PR is fully handled, at the end of this method.
         self.current_pr = pr.number
 
         result = _run_reversal_for_pr(
@@ -587,15 +557,12 @@ class StreamFarmer:
         # Show result
         self._print_result(result)
 
-        # A publish failure or a failed state push ends the run. Checked together: both can
-        # fail in the same iteration, and reporting only the first would tell the operator
-        # farm state was preserved when it was not. current_pr stays set here on purpose:
-        # the abort report should name the PR we stopped on.
+        # A publish failure and a failed state push can occur in the same iteration, so
+        # both are reported. current_pr stays set: an abort report should name the PR.
         if self._check_publish_health(result, state_saved):
             return
 
-        # This PR is fully handled. Anything that crashes from here to the next PR is the
-        # fetcher's, and the report will say pr_in_flight=None.
+        # This PR is fully handled; a later crash is the fetcher's, and reports no PR.
         self.current_pr = None
 
         # Rate limit protection: only sleep after PRs that actually ran a CC session
@@ -842,11 +809,8 @@ class StreamFarmer:
         work actually done, and a resumed sandbox would redo it. Exiting 0 would tell a
         supervisor everything was fine.
         """
-        # This is the most consequential save of the run: it carries the run report. If it
-        # never lands, the state branch is left holding the "running" marker from startup -
-        # which is our silent-kill signature - so a run that actually crashed or completed
-        # would be indistinguishable from one that was OOM-killed. Worth retrying rather
-        # than accepting on a single transient failure.
+        # Carries the run report, so a transient push failure is retried rather than
+        # leaving the branch without an explanation for this run.
         if not self._save_state_with_retry():
             self.aborted = True
             self.console.print(

--- a/src/swegen/farm/stream_farm.py
+++ b/src/swegen/farm/stream_farm.py
@@ -46,6 +46,11 @@ _DETAIL_MAX_CHARS = 2000
 _MESSAGE_MAX_CHARS = 500
 _REASON_MAX_CHARS = 1000
 
+# The final save carries the run report. If it never lands, the branch keeps the "running"
+# marker and a crashed run is indistinguishable from an OOM kill - so retry it.
+_FINAL_SAVE_ATTEMPTS = 3
+_FINAL_SAVE_BACKOFF_SECONDS = 3.0
+
 
 def docker_cleanup_cmds(build_cache_keep: str) -> list[str]:
     """Docker cleanup steps, in order.
@@ -304,24 +309,23 @@ class StreamFarmer:
             # _abort() already wrote the report, with its own reason.
             return
 
-        if self.shutdown_requested:
-            # SIGINT/SIGTERM. _handle_shutdown only sets a flag - it never raises - so the
-            # KeyboardInterrupt branch in run() does NOT fire for a signal, and without
-            # this the report would be left saying "running": the silent-kill signature.
-            # SIGTERM is exactly what a sandbox stop sends, so this must not look like a
-            # crash.
-            self._record_outcome("interrupted", "Shutdown requested (SIGINT/SIGTERM)")
-            return
-
+        # stop_reason is checked BEFORE shutdown_requested on purpose. A signal can arrive
+        # while a page fetch is failing, and the API failure is the substantive cause: it is
+        # what a re-run has to overcome. Checking the signal first would drop stop_reason
+        # AND file the run as `interrupted`, which does not set aborted - so run() could
+        # return 0 on a stream failure, reporting a broken run as a healthy one.
         if self.fetcher.stop_reason:
-            # The fetcher swallowed a page-fetch error and broke out. Not exhaustion, and
-            # not a crash: the run stopped early and should be retried.
+            # The fetcher gave up on a page fetch and broke out. Not exhaustion, and not a
+            # crash: the run stopped early and should be retried.
             self.aborted = True  # exit 1: this run did not finish its work
-            self._record_outcome("stream_failed", self.fetcher.stop_reason)
+            reason = self.fetcher.stop_reason
+            if self.shutdown_requested:
+                reason = f"{reason} (a shutdown signal also arrived)"
+            self._record_outcome("stream_failed", reason)
             self.console.print(
                 Panel(
                     Text(
-                        f"{self.fetcher.stop_reason}\n\n"
+                        f"{reason}\n\n"
                         f"The PR stream stopped early - this is NOT an exhausted history. "
                         f"Re-run to continue from the cursor.",
                         style="red",
@@ -330,6 +334,15 @@ class StreamFarmer:
                     border_style="red",
                 )
             )
+            return
+
+        if self.shutdown_requested:
+            # SIGINT/SIGTERM. _handle_shutdown only sets a flag - it never raises - so the
+            # KeyboardInterrupt branch in run() does NOT fire for a signal, and without
+            # this the report would be left saying "running": the silent-kill signature.
+            # SIGTERM is exactly what a sandbox stop sends, so this must not look like a
+            # crash.
+            self._record_outcome("interrupted", "Shutdown requested (SIGINT/SIGTERM)")
             return
 
         self._record_outcome("completed", "PR stream exhausted")
@@ -825,13 +838,36 @@ class StreamFarmer:
         work actually done, and a resumed sandbox would redo it. Exiting 0 would tell a
         supervisor everything was fine.
         """
-        if not self._save_state():
+        # This is the most consequential save of the run: it carries the run report. If it
+        # never lands, the state branch is left holding the "running" marker from startup -
+        # which is our silent-kill signature - so a run that actually crashed or completed
+        # would be indistinguishable from one that was OOM-killed. Worth retrying rather
+        # than accepting on a single transient failure.
+        if not self._save_state_with_retry():
             self.aborted = True
             self.console.print(
-                "[red]Final state push failed - the durable cursor is stale. "
-                "Recover the local state mirror before this sandbox is reclaimed.[/red]"
+                "[red]Final state push failed after "
+                f"{_FINAL_SAVE_ATTEMPTS} attempts - the durable cursor is stale and the "
+                "state branch still says 'running'. The full run report IS in the local "
+                f"mirror ({self.state_file}); recover it before this sandbox is "
+                "reclaimed.[/red]"
             )
         self._save_log()
+
+    def _save_state_with_retry(self) -> bool:
+        """Save the state, retrying a transient push failure with backoff."""
+        for attempt in range(1, _FINAL_SAVE_ATTEMPTS + 1):
+            if self._save_state():
+                return True
+            if attempt == _FINAL_SAVE_ATTEMPTS:
+                break
+            delay = _FINAL_SAVE_BACKOFF_SECONDS * attempt
+            self.console.print(
+                f"[yellow]State push failed; retrying in {delay:.0f}s "
+                f"(attempt {attempt}/{_FINAL_SAVE_ATTEMPTS})[/yellow]"
+            )
+            time.sleep(delay)
+        return False
 
         self.console.print("\n")
         self.console.print(Rule(Text("Final Summary", style="bold magenta")))


### PR DESCRIPTION
## Problem

When a farm run stops, the state branch cannot say why.

The farm only recorded per-PR outcomes. Nothing recorded why the *run itself* ended, so a crash, an OOM kill, a reclaimed sandbox and a clean completion were all indistinguishable — the state simply stopped advancing. On an ephemeral sandbox, where the console output dies with the container, that means no post-mortem is possible at all.

`farm-state/elastic__beats` is a live example: no abort recorded, 21 PRs processed, six days into a ~51,800-PR repo. Clearly not a graceful stop and clearly not an exhausted history — and the state has nothing more to say.

## Change

Every exit path now writes a `last_run` report into the state, pushed to the state branch by `_finalize()`.

| outcome | meaning |
|---|---|
| `running` | written before any work. Nothing overwrites it if the process is killed outright, so a report left at `running` means the run never reached an exit. |
| `completed` | PR history exhausted |
| `stream_failed` | the fetcher gave up on a GitHub API error. The generator ends identically to genuine exhaustion, so this is teased apart explicitly and exits 1. |
| `aborted` | graceful stop (publish failure, state-push failure, Claude rate limit) |
| `interrupted` | SIGINT/SIGTERM |
| `crashed` | unhandled exception: type, message, capped traceback tail |

The report also carries:

- **`pr_in_flight`** — null on a crash means the failure was between PRs, i.e. in the fetcher rather than in task generation. Set, it names the PR.
- `last_pr_number`, counters, `pending_retry` sets, the last few PR results with categories
- run duration, host / sandbox id, and swegen / SDK / harbor / python versions

`run()` no longer lets exceptions escape: it records, prints a panel, and returns 1.

## Notes

- **Startup and final saves are retried.** Both carry the report. The startup push aborts the run if it cannot land — the state branch is what a resumed sandbox depends on, and farming on would spend a full Claude Code session before hitting the same failure.
- **A stream failure outranks a signal.** A SIGTERM can arrive while a page fetch is failing; the API error is the condition a re-run must overcome, and unlike `interrupted` it exits non-zero.
- **`merge_from` keeps the later report** (by `ended_at`, or `started_at` while in flight), so a terminal outcome is not replaced by an in-flight marker from an earlier-started run.
- Free-text fields are capped and the report is written only on run start and exit — not per PR — so the branch stays small (~1KB per run).

## Residual gap

If GitHub is unreachable, the report cannot be pushed at all; the branch keeps whatever it last held and the full report survives only in the local mirror. That case is what an external supervisor's exit code is for.

## Verification

All exit paths, plus: a fetcher raising between PRs (`crashed`, `pr_in_flight: null`); a crash during task generation (`pr_in_flight` set); a stream failure with a concurrent SIGTERM (`stream_failed`, exit 1); a transient startup push (retried, run proceeds); a persistent one (aborts before farming); the final summary still printing; and the report round-tripping through the state JSON.
