### PR TITLE
feat(farm): retry transient GitHub failures instead of ending the run

### DIFF
--- a/src/swegen/farm/fetcher.py
+++ b/src/swegen/farm/fetcher.py
@@ -15,6 +15,19 @@ from swegen.create import is_test_file
 from .farm_hand import PRCandidate, _slug
 from .state import StreamState
 
+# A single transient GitHub failure used to end the whole run: the page fetch gave up on
+# the first error. At this call volume a 5xx or a dropped connection is routine, so pages
+# are retried with backoff and only a persistent failure stops the stream.
+_MAX_PAGE_ATTEMPTS = 5
+_BACKOFF_BASE_SECONDS = 2.0
+_MAX_BACKOFF_SECONDS = 60.0
+# Rate-limit resets can be far out; wait for one rather than burning an attempt, but do
+# not sit for an unbounded stretch.
+_MAX_RATE_LIMIT_WAIT_SECONDS = 300.0
+
+# Worth another try: server-side wobble or throttling, both of which pass.
+_RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
+
 
 def load_skip_list(skip_list_file: Path, repo: str) -> set[int]:
     """Load PR numbers from a skip list file for the given repository.
@@ -112,6 +125,102 @@ class StreamingPRFetcher:
         if self.github_token:
             self.headers["Authorization"] = f"token {self.github_token}"
 
+    def _rate_limit_wait(self, resp: requests.Response) -> float | None:
+        """Seconds to wait if `resp` is a rate-limit rejection, else None.
+
+        GitHub signals a primary rate limit as 403/429 with X-RateLimit-Remaining: 0, and a
+        secondary one with Retry-After. Both clear on their own, so both are worth waiting
+        out rather than abandoning the run.
+        """
+        retry_after = resp.headers.get("Retry-After")
+        if retry_after:
+            try:
+                return min(float(retry_after), _MAX_RATE_LIMIT_WAIT_SECONDS)
+            except ValueError:
+                pass
+
+        if resp.status_code in (403, 429) and resp.headers.get("X-RateLimit-Remaining") == "0":
+            reset = resp.headers.get("X-RateLimit-Reset")
+            if reset:
+                try:
+                    wait = float(reset) - time.time()
+                except ValueError:
+                    return None
+                if wait > 0:
+                    return min(wait + 1, _MAX_RATE_LIMIT_WAIT_SECONDS)
+                return 0.0
+        return None
+
+    def _get_page_with_retry(
+        self, url: str, params: dict[str, Any], page: int
+    ) -> requests.Response | None:
+        """Fetch one page of PRs, retrying transient failures.
+
+        Returns the response, or None when the stream should stop - in which case
+        stop_reason is set so the farmer can report a failure rather than an exhaust.
+
+        Retries a 5xx, a rate limit, and any network/timeout error: at this call volume
+        those are routine and self-clearing, and abandoning the run over one costs an
+        entire farm. Does NOT retry a 401/403-without-rate-limit/404 - a bad token or a
+        missing repo will not fix itself, so retrying only delays the real error.
+        """
+        last_error = "unknown"
+
+        for attempt in range(1, _MAX_PAGE_ATTEMPTS + 1):
+            try:
+                resp = requests.get(url, headers=self.headers, params=params, timeout=30)
+            except requests.exceptions.RequestException as exc:
+                # Connection reset, DNS, timeout: always transient.
+                last_error = f"{type(exc).__name__}: {exc}"
+                if attempt == _MAX_PAGE_ATTEMPTS:
+                    break
+                delay = min(_BACKOFF_BASE_SECONDS * 2 ** (attempt - 1), _MAX_BACKOFF_SECONDS)
+                self.console.print(
+                    f"[yellow]Page {page}: {last_error} - retrying in {delay:.0f}s "
+                    f"(attempt {attempt}/{_MAX_PAGE_ATTEMPTS})[/yellow]"
+                )
+                time.sleep(delay)
+                continue
+
+            if resp.status_code < 400:
+                return resp
+
+            wait = self._rate_limit_wait(resp)
+            if wait is not None:
+                # Throttled. Waiting it out does not consume an attempt - the request was
+                # never really tried - or a long limit would burn the whole budget.
+                self.console.print(
+                    f"[yellow]Page {page}: rate limited ({resp.status_code}), "
+                    f"waiting {wait:.0f}s...[/yellow]"
+                )
+                time.sleep(wait)
+                continue
+
+            last_error = f"HTTP {resp.status_code} {resp.reason}"
+            if resp.status_code not in _RETRYABLE_STATUS:
+                # 401 (bad token), 404 (no such repo), 403 (no access): terminal.
+                self.stop_reason = f"GitHub API error on page {page}: {last_error}"
+                self.console.print(f"[red]API error on page {page}: {last_error}[/red]")
+                return None
+
+            if attempt == _MAX_PAGE_ATTEMPTS:
+                break
+            delay = min(_BACKOFF_BASE_SECONDS * 2 ** (attempt - 1), _MAX_BACKOFF_SECONDS)
+            self.console.print(
+                f"[yellow]Page {page}: {last_error} - retrying in {delay:.0f}s "
+                f"(attempt {attempt}/{_MAX_PAGE_ATTEMPTS})[/yellow]"
+            )
+            time.sleep(delay)
+
+        self.stop_reason = (
+            f"GitHub API error on page {page} after {_MAX_PAGE_ATTEMPTS} attempts: {last_error}"
+        )
+        self.console.print(
+            f"[red]API error on page {page}, giving up after "
+            f"{_MAX_PAGE_ATTEMPTS} attempts: {last_error}[/red]"
+        )
+        return None
+
     def stream_prs(
         self,
         resume_from_time: str | None = None,
@@ -176,16 +285,12 @@ class StreamingPRFetcher:
             url = f"{self.api_base}/repos/{self.repo}/pulls"
             params: dict[str, Any] = {**params_base, "page": page}
 
-            try:
-                resp = requests.get(url, headers=self.headers, params=params, timeout=30)
-                resp.raise_for_status()
-            except requests.exceptions.RequestException as exc:
-                self.console.print(f"[red]API error on page {page}: {exc}[/red]")
+            resp = self._get_page_with_retry(url, params, page)
+            if resp is None:
+                # Retries exhausted, or a failure that will never self-heal (401/404).
+                # _get_page_with_retry has set stop_reason, which is what lets the farmer
+                # report this as stream_failed rather than a clean exhaust.
                 skipped_stats["api_error"] += 1
-                # Record WHY we are giving up. Breaking here ends the generator exactly as
-                # exhaustion would, so without this the farmer cannot tell a GitHub outage
-                # from "no PRs left" and would file the run as completed.
-                self.stop_reason = f"GitHub API error on page {page}: {exc}"
                 break
 
             prs = resp.json()

--- a/src/swegen/farm/fetcher.py
+++ b/src/swegen/farm/fetcher.py
@@ -33,6 +33,11 @@ _MAX_RATE_LIMIT_WAITS = 3
 # Worth another try: server-side wobble or throttling, both of which pass.
 _RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
 
+# Only these can be a rate limit. Retry-After is NOT exclusive to rate limits (a 503 often
+# carries one), so the status has to gate the decision or a 5xx would take the rate-limit
+# path and a 401/404 would stop failing fast.
+_RATE_LIMIT_STATUS = frozenset({403, 429})
+
 
 def load_skip_list(skip_list_file: Path, repo: str) -> set[int]:
     """Load PR numbers from a skip list file for the given repository.
@@ -134,9 +139,18 @@ class StreamingPRFetcher:
         """Seconds to wait if `resp` is a rate-limit rejection, else None.
 
         GitHub signals a primary rate limit as 403/429 with X-RateLimit-Remaining: 0, and a
-        secondary one with Retry-After. Both clear on their own, so both are worth waiting
-        out rather than abandoning the run.
+        secondary one as 403/429 with Retry-After. Both clear on their own, so both are
+        worth waiting out rather than abandoning the run.
+
+        The STATUS is checked first, and Retry-After alone is never enough. That header is
+        not exclusive to rate limits - a 503 routinely carries one - and trusting it on its
+        own would route a 5xx down the rate-limit path (waits that spend no retry budget,
+        logged as "rate limited") and, worse, stop a 401/404 from failing on the first
+        response as it must.
         """
+        if resp.status_code not in _RATE_LIMIT_STATUS:
+            return None
+
         retry_after = resp.headers.get("Retry-After")
         if retry_after:
             try:
@@ -144,7 +158,7 @@ class StreamingPRFetcher:
             except ValueError:
                 pass
 
-        if resp.status_code in (403, 429) and resp.headers.get("X-RateLimit-Remaining") == "0":
+        if resp.headers.get("X-RateLimit-Remaining") == "0":
             reset = resp.headers.get("X-RateLimit-Reset")
             if reset:
                 try:

--- a/src/swegen/farm/fetcher.py
+++ b/src/swegen/farm/fetcher.py
@@ -165,9 +165,12 @@ class StreamingPRFetcher:
                     wait = float(reset) - time.time()
                 except ValueError:
                     return None
-                if wait > 0:
-                    return min(wait + 1, _MAX_RATE_LIMIT_WAIT_SECONDS)
-                return 0.0
+                # Never zero. At the reset boundary GitHub can still report Remaining: 0
+                # while the reset timestamp has just passed (or the clock is skewed), and a
+                # zero-length wait would spin: three instant "waits" would exhaust the wait
+                # budget in milliseconds and kill the stream just as the limit was clearing.
+                # The +1s buffer matches the proactive rate-limit check below.
+                return min(max(wait, 0.0) + 1.0, _MAX_RATE_LIMIT_WAIT_SECONDS)
         return None
 
     def _get_page_with_retry(

--- a/src/swegen/farm/fetcher.py
+++ b/src/swegen/farm/fetcher.py
@@ -144,7 +144,9 @@ class StreamingPRFetcher:
         retry_after = resp.headers.get("Retry-After")
         if retry_after:
             try:
-                return min(float(retry_after), _MAX_RATE_LIMIT_WAIT_SECONDS)
+                # Floored, like the reset path below: a zero wait would spin through the
+                # wait budget without giving the limit time to clear.
+                return min(max(float(retry_after), 0.0) + 1.0, _MAX_RATE_LIMIT_WAIT_SECONDS)
             except ValueError:
                 pass
 

--- a/src/swegen/farm/fetcher.py
+++ b/src/swegen/farm/fetcher.py
@@ -21,9 +21,14 @@ from .state import StreamState
 _MAX_PAGE_ATTEMPTS = 5
 _BACKOFF_BASE_SECONDS = 2.0
 _MAX_BACKOFF_SECONDS = 60.0
-# Rate-limit resets can be far out; wait for one rather than burning an attempt, but do
-# not sit for an unbounded stretch.
-_MAX_RATE_LIMIT_WAIT_SECONDS = 300.0
+
+# A rate limit is not a failure - it is GitHub telling us exactly when to come back - so a
+# wait does not consume a retry attempt. GitHub's primary limit resets on the hour, so the
+# ceiling is generous enough to sit one out (the proactive check further down already
+# sleeps to the reset uncapped). The number of waits is bounded instead, so a bogus header
+# cannot park the farm forever.
+_MAX_RATE_LIMIT_WAIT_SECONDS = 3600.0
+_MAX_RATE_LIMIT_WAITS = 3
 
 # Worth another try: server-side wobble or throttling, both of which pass.
 _RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
@@ -165,16 +170,26 @@ class StreamingPRFetcher:
         missing repo will not fix itself, so retrying only delays the real error.
         """
         last_error = "unknown"
+        # An explicit counter, not `for attempt in range(...)`: a rate-limit wait must NOT
+        # advance it. With a for-loop, `continue` after a wait silently burns an attempt,
+        # so a primary limit whose reset is an hour out would exhaust the budget waiting and
+        # then kill the run - the opposite of the intent.
+        attempt = 0
+        rate_limit_waits = 0
 
-        for attempt in range(1, _MAX_PAGE_ATTEMPTS + 1):
+        def _backoff(n: int) -> float:
+            return min(_BACKOFF_BASE_SECONDS * 2 ** (n - 1), _MAX_BACKOFF_SECONDS)
+
+        while attempt < _MAX_PAGE_ATTEMPTS:
             try:
                 resp = requests.get(url, headers=self.headers, params=params, timeout=30)
             except requests.exceptions.RequestException as exc:
                 # Connection reset, DNS, timeout: always transient.
+                attempt += 1
                 last_error = f"{type(exc).__name__}: {exc}"
-                if attempt == _MAX_PAGE_ATTEMPTS:
+                if attempt >= _MAX_PAGE_ATTEMPTS:
                     break
-                delay = min(_BACKOFF_BASE_SECONDS * 2 ** (attempt - 1), _MAX_BACKOFF_SECONDS)
+                delay = _backoff(attempt)
                 self.console.print(
                     f"[yellow]Page {page}: {last_error} - retrying in {delay:.0f}s "
                     f"(attempt {attempt}/{_MAX_PAGE_ATTEMPTS})[/yellow]"
@@ -187,15 +202,26 @@ class StreamingPRFetcher:
 
             wait = self._rate_limit_wait(resp)
             if wait is not None:
-                # Throttled. Waiting it out does not consume an attempt - the request was
-                # never really tried - or a long limit would burn the whole budget.
+                # Throttled. GitHub told us when to come back, so this is not a failed
+                # attempt - do not touch `attempt`. Bound the number of waits instead, so a
+                # malformed reset header cannot park the farm indefinitely.
+                rate_limit_waits += 1
+                last_error = f"HTTP {resp.status_code} {resp.reason} (rate limited)"
+                if rate_limit_waits > _MAX_RATE_LIMIT_WAITS:
+                    last_error = (
+                        f"still rate limited after {_MAX_RATE_LIMIT_WAITS} waits "
+                        f"({resp.status_code} {resp.reason})"
+                    )
+                    break
                 self.console.print(
-                    f"[yellow]Page {page}: rate limited ({resp.status_code}), "
-                    f"waiting {wait:.0f}s...[/yellow]"
+                    f"[yellow]Page {page}: rate limited ({resp.status_code}), waiting "
+                    f"{wait:.0f}s (wait {rate_limit_waits}/{_MAX_RATE_LIMIT_WAITS}, "
+                    f"does not count as a retry)...[/yellow]"
                 )
                 time.sleep(wait)
                 continue
 
+            attempt += 1
             last_error = f"HTTP {resp.status_code} {resp.reason}"
             if resp.status_code not in _RETRYABLE_STATUS:
                 # 401 (bad token), 404 (no such repo), 403 (no access): terminal.
@@ -203,22 +229,19 @@ class StreamingPRFetcher:
                 self.console.print(f"[red]API error on page {page}: {last_error}[/red]")
                 return None
 
-            if attempt == _MAX_PAGE_ATTEMPTS:
+            if attempt >= _MAX_PAGE_ATTEMPTS:
                 break
-            delay = min(_BACKOFF_BASE_SECONDS * 2 ** (attempt - 1), _MAX_BACKOFF_SECONDS)
+            delay = _backoff(attempt)
             self.console.print(
                 f"[yellow]Page {page}: {last_error} - retrying in {delay:.0f}s "
                 f"(attempt {attempt}/{_MAX_PAGE_ATTEMPTS})[/yellow]"
             )
             time.sleep(delay)
 
-        self.stop_reason = (
-            f"GitHub API error on page {page} after {_MAX_PAGE_ATTEMPTS} attempts: {last_error}"
-        )
-        self.console.print(
-            f"[red]API error on page {page}, giving up after "
-            f"{_MAX_PAGE_ATTEMPTS} attempts: {last_error}[/red]"
-        )
+        # Reached either by exhausting retry attempts or by exhausting rate-limit waits;
+        # last_error says which, so the run report names the real cause.
+        self.stop_reason = f"GitHub API error on page {page}, gave up: {last_error}"
+        self.console.print(f"[red]API error on page {page}, giving up: {last_error}[/red]")
         return None
 
     def stream_prs(


### PR DESCRIPTION
> **Stacked on #63** (`feat/farm-crash-report`), which adds the `stop_reason` field this builds on. Base will be retargeted to `main` once #63 lands.

## Problem

The PR stream gave up on the **first** page-fetch error:

```python
except requests.exceptions.RequestException as exc:
    ...
    break          # one 502 and the entire run is over
```

At this call volume a 5xx or a dropped connection is routine, so a single transient GitHub blip ended a whole farm run. This is the most likely reason runs keep dying after only a handful of PRs (`farm-state/elastic__beats`: 21 PRs into a ~51,800-PR repo, no abort recorded).

## Change

Pages are fetched with bounded retry and exponential backoff (5 attempts, 2s doubling, capped at 60s).

| | |
|---|---|
| **retried** | 5xx, and any network/timeout error — transient, and clear on their own |
| **waited** | rate limits (403/429 with `X-RateLimit-Remaining: 0`, or `Retry-After`). A rate limit says when to come back, so waiting one out does **not** consume a retry attempt; the number of waits is bounded instead (3), so a malformed reset header cannot stall the run. The wait ceiling covers GitHub's hourly primary reset, and is floored at 1s so a reset already in the past cannot spin. |
| **terminal** | 401, 404, and 403 without rate-limit headers — a bad token or a missing repo will not fix itself, so these fail on the **first** response rather than stalling before surfacing the real error |

Only a persistent failure stops the stream, and it sets `stop_reason`, so the farmer reports `stream_failed` with the real GitHub error rather than a clean exhaust.

`Retry-After` is not exclusive to rate limits — a 503 routinely carries one — so the **status**, not the header, decides which path a response takes.

## Verification

- `502, 502, 200` → recovers; connection reset → recovers
- 3 rate-limit waits + 2 transient 502s + a 200 → succeeds (waits do not consume attempts)
- rate limit with the reset already past → floored wait, recovers rather than spinning
- `503` + `Retry-After` → 5xx retry budget, not the rate-limit path
- `401`, `404`, `403`-without-headers → fail on the first call
- persistent `502` → gives up after 5 attempts with the real error in `stop_reason`
- perpetual rate limit → bounded after 3 waits, naming the cause

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes long-running farm behavior around GitHub API failure handling (sleeps, retry vs terminal classification); misclassification could stall runs or mask auth/config errors, but scope is limited to list pagination in `fetcher.py`.
> 
> **Overview**
> **GitHub PR list pagination** no longer aborts the farm run on the first page-fetch error. `stream_prs` delegates each page to `_get_page_with_retry`, which applies bounded retries with exponential backoff instead of a single `requests.get` + immediate `break`.
> 
> **Transient failures** (5xx, 429 outside the rate-limit wait path, connection/DNS/timeout errors) get up to five attempts with 2s-doubling backoff capped at 60s. **Rate limits** on 403/429 are handled separately via `_rate_limit_wait` (`Retry-After` or `X-RateLimit-Reset` when remaining is 0): sleeps do not consume retry attempts, waits are capped (3 waits, max ~1h), and a 503 with `Retry-After` stays on the 5xx retry path because only those statuses trigger the rate-limit branch.
> 
> **Terminal errors** (401, 404, 403 without rate-limit signals) fail immediately with `stop_reason` set so upstream can distinguish API failure from natural exhaustion. Persistent failure after retries also sets `stop_reason` with the last error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1e9f0b7db75b8bb3a88ef9a717eb9458f321161. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->